### PR TITLE
Website encryption fix

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -409,7 +409,7 @@ message MeshPacket {
   /*
    * The sending node number.
    * Note: Our crypto implementation uses this field as well.
-   * See [crypto](/software/other/crypto.md) for details.
+   * See [crypto](/developers/device/encryption.md) for details.
    * FIXME - really should be fixed32 instead, this encoding only hurts the ble link though.
    */
   fixed32 from = 1; 

--- a/mesh.proto
+++ b/mesh.proto
@@ -432,7 +432,7 @@ message MeshPacket {
   uint32 channel = 3;
   
   /*
-   * Internally to the mesh radios we will route SubPackets encrypted per [this](/software/other/crypto.md).
+   * Internally to the mesh radios we will route SubPackets encrypted per [this](/developers/device/encryption.md).
    * However, when a particular node has the correct
    * key to decode a particular packet, it will decode the payload into a SubPacket protobuf structure.
    * Software outside of the device nodes will never encounter a packet where
@@ -453,7 +453,7 @@ message MeshPacket {
    * needs to be unique for a few minutes (long enough to last for the length of
    * any ACK or the completion of a mesh broadcast flood).
    * Note: Our crypto implementation uses this id as well.
-   * See [crypto](/software/other/crypto.md) for details.
+   * See [crypto](/developers/device/encryption.md) for details.
    * FIXME - really should be fixed32 instead, this encoding only
    * hurts the ble link though.
    */


### PR DESCRIPTION
A fix to change the link to the new location for the encryption commentary.