### PR TITLE
Add Options For Go Protobuf Generation

### DIFF
--- a/admin.proto
+++ b/admin.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 import "mesh.proto";
 import "radioconfig.proto";

--- a/apponly.proto
+++ b/apponly.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 import "channel.proto";
 

--- a/channel.proto
+++ b/channel.proto
@@ -20,7 +20,9 @@ syntax = "proto3";
  */
 
 option java_package = "com.geeksville.mesh";
+
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 option java_outer_classname = "ChannelProtos";
 

--- a/deviceonly.proto
+++ b/deviceonly.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 import "mesh.proto";
 import "channel.proto";

--- a/environmental_measurement.proto
+++ b/environmental_measurement.proto
@@ -1,4 +1,5 @@
 syntax = "proto3";
+option go_package = "github.com/meshtastic/gomeshproto";
 
 message EnvironmentalMeasurement {
 

--- a/mesh.proto
+++ b/mesh.proto
@@ -21,6 +21,7 @@ syntax = "proto3";
 
 option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 import "portnums.proto";
 

--- a/mqtt.proto
+++ b/mqtt.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 import "mesh.proto";
 

--- a/portnums.proto
+++ b/portnums.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "Portnums";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 /*
  * For any new 'apps' that run on the device or via sister apps on phones/PCs they should pick and use a

--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -22,6 +22,7 @@ syntax = "proto3";
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "RadioConfigProtos";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 /*
  * The frequency/regulatory region the user has selected.

--- a/remote_hardware.proto
+++ b/remote_hardware.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "RemoteHardware";
 option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
 
 /*
  * An example app to show off the plugin system. This message is used for 


### PR DESCRIPTION
This PR is to add the required parameters (`option go_package`) to the existing Protobufs to allow Go code to be generated. The code changes are very small and consist of adding `option go_package = "github.com/meshtastic/gomeshproto"` to each `.proto` file to allow for `protoc` to generate the required files. 

One thing to note is I chose `github.com/meshtastic/gomeshproto` as an arbitrary package name since there isn't currently a package for any compiled protobuf files that I could find. This shouldn't cause any issues in projects because developers using the Protobuf files for Go could 1) compile the files and then move them to be a local package in their project or 2) setup a `replace` directive in `go.mod` to point to the files at `github.com/meshtastic/gomeshproto`. 

I'm hoping it may be possible to add an actual package that contains the compiled Go Protobufs at some point to make managing versions easier, but this should be enough for now to help with development. 