### PR TITLE
Added Plus Codes and OS Grid Reference

### DIFF
--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -143,7 +143,17 @@ enum GpsCoordinateFormat {
    */
   GpsFormatMGRS = 3;
 
-  // GpsFormatOLC = 4; // Plus Codes, maybe one day?
+  /*
+   * GPS coordinates are displayed in Open Location Code (aka Plus Codes).
+   */
+  GpsFormatOLC = 4;
+  
+  /*
+   * GPS coordinates are displayed in Ordnance Survey Grid Reference (the National Grid System of the UK).
+   * Format: AB EEEEE NNNNN, where A is the east 100k square, B is the north 100k square, E is the easting,
+   * N is the northing
+   */
+  GpsFormatOSGR = 5;
 }
 
 /*


### PR DESCRIPTION
Added GPS coordinate format options for Google's Open Location Codes and the United Kingdom's Ordnance Survey Grid Reference System.