### PR TITLE
Custom DIY device hardware model identifier based on @NanoVHF schematics

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -113,6 +113,11 @@ message Position {
      * The simulator built into the android app
      */
     ANDROID_SIM = 38;
+
+    /*
+     * Custom DIY device based on @NanoVHF schematics: https://github.com/NanoVHF/Meshtastic-DIY/tree/main/Schematics
+     */
+    DIY_V1 = 39;
   }
 
 /*


### PR DESCRIPTION
Custom DIY device based on @NanoVHF schematics: https://github.com/NanoVHF/Meshtastic-DIY/tree/main/Schematics

Configuration to meshtastic-device `platformio.ini` and `configuration.h` is upcoming.