### PR TITLE
add a Team field in USER message

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -255,11 +255,11 @@ enum Team {
     RED = 6;
     MAROON = 7;
     PURPLE = 8;
-    DARKBLUE = 9;
+    DARK_BLUE = 9;
     BLUE = 10;
     TEAL = 11;
     GREEN = 12;
-    DARKGREEN = 13;
+    DARK_GREEN = 13;
     BROWN = 14;
 }
 


### PR DESCRIPTION
(explanation is also included in code comments)
Participants in the same network can self-group into different teams.
Short-term this can be used to visually differentiate them on the map; in the longer term it could also help users to semi-automatically select or ignore messages according to team affiliation. 

In total, 14 teams are defined (encoded in 4 bits)