### PR TITLE
Add is_always_powered user preference

### DIFF
--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -548,6 +548,12 @@ message RadioConfig {
      * (bitwise OR of PositionFlags)
      */
     uint32 position_flags = 150;
+    
+    /*
+     * Circumvents the logic block for determining whether the device is powered or not. 
+     * Useful for devices with finicky ADC issues on the battery sense pins.
+     */
+    bool always_powered = 151;
   }
 
   UserPreferences preferences = 1;

--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -553,7 +553,7 @@ message RadioConfig {
      * Circumvents the logic block for determining whether the device is powered or not. 
      * Useful for devices with finicky ADC issues on the battery sense pins.
      */
-    bool always_powered = 151;
+    bool is_always_powered = 151;
   }
 
   UserPreferences preferences = 1;


### PR DESCRIPTION
At the request of some users (mostly on the discord group) having issues with device sleeping in some instances where the battery ADC is not reliable enough to be trusted, I'm proposing this user preference to circumvent the logic in powerFSM.cpp (which I will create another PR for). 
I have personally used this in the form of a #define ALWAYS_POWERED, but I've seen enough interest in it that I feel it deserves a spot in the user preferences.