### PR TITLE
Add on_battery_shutdown_after_secs preference

### DIFF
--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -569,6 +569,12 @@ message RadioConfig {
      * Potentially useful for devices without user buttons.
      */
     uint32 auto_screen_carousel_secs = 152;
+
+    /*
+     * If non-zero, the device will fully power off this many seconds after external power is removed.
+     * 
+     */
+    uint32 on_battery_shutdown_after_secs = 153;
   }
 
   UserPreferences preferences = 1;


### PR DESCRIPTION
The intention being if this is set >0, a node will power off this long after being disconnected from power (or this long after being turned on when on battery)