### PR TITLE
Ham, not HAM

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -325,7 +325,7 @@ message User {
   HardwareModel hw_model = 6;
 
   /*
-   * In some regions HAM radio operators have different bandwidth limitations than others.
+   * In some regions Ham radio operators have different bandwidth limitations than others.
    * If this user is a licensed operator, set this flag.
    * Also, "long_name" should be their licence number.
    */


### PR DESCRIPTION
Originally discovered in https://github.com/meshtastic/Meshtastic/pull/160/commits/1ffa55d39a8270686c8ba087634d31826c0f4a33

https://www.kb6nu.com/ham-ham-radio-ham-radio-amateur-radio/#:~:text=Of%20course%20either%20term%20may,be%20avoided%20at%20all%20costs.