### PR TITLE
Add a user preference to control MQTT encryption

### DIFF
--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -682,6 +682,15 @@ message RadioConfig {
      * ExternalNotificationPlugin can benefit from this feature.
      */
     bool canned_message_plugin_send_bell = 173;
+
+    /*
+     * Whether to send encrypted or decrypted packets to MQTT.
+     * This parameter is only honoured if you also set mqtt_server
+     * (the default official mqtt.meshtastic.org server can handle encrypted packets)
+     * 
+     * Decrypted packets may be useful for external systems that want to consume meshtastic packets
+     */
+    bool mqtt_encryption_enabled = 174;
   }
   UserPreferences preferences = 1;
 


### PR DESCRIPTION
If you run your own mqtt broker and want to consume meshtastic traffic in another application, it'd sure be easier if the protobufs were decrypted on device first.  We should have a switch to allow this to happen.

The way this is worded will mean that if you connect your device to a custom mqtt broker, upon performing this update on your device, it will by default decrypt protobufs going to mqtt.  This is a change from current behaviour.  

It should not affect mesh bridging over mqtt either way.