### PR TITLE
Brother EP-44 support

### DIFF
--- a/radioconfig.proto
+++ b/radioconfig.proto
@@ -619,6 +619,10 @@ message RadioConfig {
       BAUD_460800 = 9;
       BAUD_576000 = 10;
       BAUD_921600 = 11;
+      BAUD_110 = 12;
+      BAUD_300 = 13;
+      BAUD_600 = 14;
+      BAUD_1200 = 15;
     };
 
     /*


### PR DESCRIPTION
Support for low rate baud rates for use of old electric typewriters with a serial port like Brother EP-44 as a Meshtastic messaging device.