### PR TITLE
Add a major identifier for m5stack hardware.

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -349,6 +349,11 @@ enum HardwareModel {
   DR_DEV = 43;
   
   /*
+   * M5 esp32 based MCU modules with enclosure, TFT and LORA Shields. All Variants (Basic, Core, Fire, Core2, Paper) https://m5stack.com/
+   */
+  M5STACK = 44;
+  
+  /*
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    */
   PRIVATE_HW = 255;


### PR DESCRIPTION
Can be used for development and definitions on all variants (Stack, Stick, Core, Core2, Epaper, Stamps)
