### PR TITLE
Add a shortname_ble boolean flag.

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -77,6 +77,12 @@ message Config {
      */
     string ntp_server = 5;
 
+    /*
+     * By default we use the MAC address to generate the BLE name. Set "shortname_ble" to true to use the
+     * shortname instead.
+     */
+    bool shortname_ble = 6;
+
   }
 
   /*


### PR DESCRIPTION
## What does this PR do?

Add a shortname_ble boolean flag, for use with https://github.com/meshtastic/Meshtastic-device/pull/1425

## Checklist before merging
- [ X ] All top level messages commented
- [ X ] All enum members have unique descriptions
- [ X ] Formatting is consistant with the defined protolint rules
(I don't have visual studio so I manually downloaded protolint and ran it on `.` and fixed the error it found. I'm not sure if there is a particular version y'all use though).
