### PR TITLE
Issue #155 - proto needs refactor for 1.3 clients

### DIFF
--- a/apponly.proto
+++ b/apponly.proto
@@ -4,8 +4,8 @@ option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
 option go_package = "github.com/meshtastic/gomeshproto";
 
-import "config.proto";
 import "channel.proto";
+import "config.proto";
 
 option java_outer_classname = "AppOnlyProtos";
 

--- a/apponly.proto
+++ b/apponly.proto
@@ -4,6 +4,7 @@ option java_package = "com.geeksville.mesh";
 option optimize_for = LITE_RUNTIME;
 option go_package = "github.com/meshtastic/gomeshproto";
 
+import "config.proto";
 import "channel.proto";
 
 option java_outer_classname = "AppOnlyProtos";
@@ -18,7 +19,12 @@ option java_outer_classname = "AppOnlyProtos";
 message ChannelSet {
 
   /*
-   * TODO: REPLACE
+   * Channel list with settings
    */
   repeated ChannelSettings settings = 1;
+
+  /*
+   * LoRa config
+   */
+  Config.LoRaConfig lora_config = 2;
 }

--- a/deviceonly.proto
+++ b/deviceonly.proto
@@ -5,12 +5,9 @@ option optimize_for = LITE_RUNTIME;
 option go_package = "github.com/meshtastic/gomeshproto";
 
 import "channel.proto";
-import "config.proto";
 import "mesh.proto";
-import "module_config.proto";
 
 option java_outer_classname = "DeviceOnly";
-
 
 /*
  * This message is never sent over the wire, but it is used for serializing DB
@@ -135,73 +132,4 @@ message OEMStore {
    * Use this font for the OEM text.
    */
   string oem_text = 5;
-}
-
-message LocalConfig {
-  /*
-   * TODO: REPLACE
-   */
-  Config.DeviceConfig device = 1;
-
-  /*
-   * TODO: REPLACE
-   */
-  Config.PositionConfig position = 2;
-
-  /*
-   * TODO: REPLACE
-   */
-  Config.PowerConfig power = 3;
-
-  /*
-   * TODO: REPLACE
-   */
-  Config.WiFiConfig wifi = 4;
-
-  /*
-   * TODO: REPLACE
-   */
-  Config.DisplayConfig display = 5;
-
-  /*
-   * TODO: REPLACE
-   */
-  Config.LoRaConfig lora = 6;
-}
-
-message LocalModuleConfig {
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.MQTTConfig mqtt = 1;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.SerialConfig serial = 2;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.ExternalNotificationConfig external_notification = 3;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.StoreForwardConfig store_forward = 4;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.RangeTestConfig range_test = 5;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.TelemetryConfig telemetry = 6;
-
-  /*
-   * TODO: REPLACE
-   */
-  ModuleConfig.CannedMessageConfig canned_message = 7;
 }

--- a/localonly.proto
+++ b/localonly.proto
@@ -1,0 +1,84 @@
+syntax = "proto3";
+
+option java_package = "com.geeksville.mesh";
+option optimize_for = LITE_RUNTIME;
+option go_package = "github.com/meshtastic/gomeshproto";
+
+import "config.proto";
+import "module_config.proto";
+
+option java_outer_classname = "LocalOnlyProtos";
+
+/*
+ * Protobuf structures common to apponly.proto and deviceonly.proto
+ * This is never sent over the wire, only for local use
+ */
+
+message LocalConfig {
+  /*
+   * TODO: REPLACE
+   */
+  Config.DeviceConfig device = 1;
+
+  /*
+   * TODO: REPLACE
+   */
+  Config.PositionConfig position = 2;
+
+  /*
+   * TODO: REPLACE
+   */
+  Config.PowerConfig power = 3;
+
+  /*
+   * TODO: REPLACE
+   */
+  Config.WiFiConfig wifi = 4;
+
+  /*
+   * TODO: REPLACE
+   */
+  Config.DisplayConfig display = 5;
+
+  /*
+   * TODO: REPLACE
+   */
+  Config.LoRaConfig lora = 6;
+}
+
+message LocalModuleConfig {
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.MQTTConfig mqtt = 1;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.SerialConfig serial = 2;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.ExternalNotificationConfig external_notification = 3;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.StoreForwardConfig store_forward = 4;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.RangeTestConfig range_test = 5;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.TelemetryConfig telemetry = 6;
+
+  /*
+   * TODO: REPLACE
+   */
+  ModuleConfig.CannedMessageConfig canned_message = 7;
+}


### PR DESCRIPTION
- Add `LoraConfig` to `apponly.proto` `ChannelSet` since it is no longer part of the primary channel.
- Create `localonly.proto` for protos common to `apponly.proto` and `deviceonly.proto`. This is never sent over the wire, only for local use. `LocalConfig` & `LocalModuleConfig` can store combined `Config` & `ModuleConfig` oneofs.

> [AppOnly Proto Needs Refactor for 1.3](https://github.com/meshtastic/Meshtastic-protobufs/issues/155)

## Checklist before merging
- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
- [ ] Formatting is consistant with the defined protolint rules
