### PR TITLE
Removed analog sensors and lame config settings

### DIFF
--- a/module_config.proto
+++ b/module_config.proto
@@ -247,34 +247,10 @@ message ModuleConfig {
     bool environment_screen_enabled = 4;
 
     /*
-     * Sometimes sensor reads can fail.
-     * If this happens, we will retry a configurable number of attempts,
-     * each attempt will be delayed by the minimum required refresh rate for that sensor
-     */
-    uint32 environment_read_error_count_threshold = 5;
-
-    /*
-     * Sometimes we can end up with more than read_error_count_threshold failures.
-     * In this case, we will stop trying to read from the sensor for a while.
-     * Wait this long until trying to read from the sensor again
-     */
-    uint32 environment_recovery_interval = 6;
-
-    /*
      * We'll always read the sensor in Celsius, but sometimes we might want to
      * display the results in Fahrenheit as a "user preference".
      */
     bool environment_display_fahrenheit = 7;
-
-    /*
-     * Specify the sensor type
-     */
-    TelemetrySensorType environment_sensor_type = 8;
-
-    /*
-     * Specify the peferred GPIO Pin for sensor readings
-     */
-    uint32 environment_sensor_pin = 9;
   }
 
   /*

--- a/telemetry.proto
+++ b/telemetry.proto
@@ -100,58 +100,34 @@ enum TelemetrySensorType {
   * No external telemetry sensor explicitly set
   */
   NotSet = 0;
-  /*
-  * Moderate accuracy temperature
-  */
-  DHT11 = 1;
-
-  /*
-  * High accuracy temperature
-  */
-  DS18B20 = 2;
 
   /*
   * Moderate accuracy temperature and humidity
   */
-  DHT12 = 3;
-
-  /*
-  * Moderate accuracy temperature and humidity
-  */
-  DHT21 = 4;
-
-  /*
-  * Moderate accuracy temperature and humidity
-  */
-  DHT22 = 5;
+  DHT22 = 1;
 
   /*
   * High accuracy temperature, pressure, humidity
   */
-  BME280 = 6;
+  BME280 = 2;
 
   /*
   * High accuracy temperature, pressure, humidity, and air resistance
   */
-  BME680 = 7;
+  BME680 = 3;
 
   /*
   * Very high accuracy temperature
   */
-  MCP9808 = 8;
-
-  /*
-  * Moderate accuracy temperature and humidity
-  */
-  SHTC3 = 9;
+  MCP9808 = 4;
 
   /*
   * Moderate accuracy current and voltage
   */
-  INA260 = 10;
+  INA260 = 5;
 
   /*
   * Moderate accuracy current and voltage
   */
-  INA219 = 11;
+  INA219 = 6;
 };


### PR DESCRIPTION
We have decided to remove analog sensorss in 1.3 in favor of "just works" i2c sensor options