### PR TITLE
'STATION_G1'

### DIFF
--- a/mesh.proto
+++ b/mesh.proto
@@ -356,6 +356,11 @@ enum HardwareModel {
   M5STACK = 44;
   
   /*
+   * B&Q Consulting Station Edition G1: https://uniteng.com/wiki/doku.php?id=meshtastic:station
+   */
+  STATION_G1 = 45; 
+
+  /*
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    */
   PRIVATE_HW = 255;


### PR DESCRIPTION
B&Q Consulting Station Edition G1 hopes to use the number 45 as HardwareModel enum, if it is possible.

About the Station G1:
The Station Edition series is a compact Lora device with high power PA (Maximum TX Power: 35dBm@915MHz or 868MHz for Station G1 Edition), Rugged SMA Antenna Socket, rich external IO interface, wide input voltage range (8VDC-20VDC). 

More Information:
https://uniteng.com/wiki/doku.php?id=meshtastic:station