### PR TITLE
removal of unused import causing error in protoc

### DIFF
--- a/module_config.proto
+++ b/module_config.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-import "telemetry.proto";
+//import "telemetry.proto";
 
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ModuleConfigProtos";

--- a/module_config.proto
+++ b/module_config.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-//import "telemetry.proto";
 
 option java_package = "com.geeksville.mesh";
 option java_outer_classname = "ModuleConfigProtos";


### PR DESCRIPTION
This PR removes an unused import that causes an error when generating code from protobufs using protoc.
