### PR TITLE
move channel_num to LoRaConfig

### DIFF
--- a/channel.options
+++ b/channel.options
@@ -3,8 +3,3 @@
 # 256 bit or 128 bit psk key
 *ChannelSettings.psk max_size:32
 *ChannelSettings.name max_size:12
-*ChannelSettings.tx_power int_size:8
-*ChannelSettings.bandwidth int_size:16
-*ChannelSettings.coding_rate int_size:8
-*ChannelSettings.channel_num int_size:8
-

--- a/channel.proto
+++ b/channel.proto
@@ -31,26 +31,9 @@ option java_outer_classname = "ChannelProtos";
 message ChannelSettings {
 
   /*
-   * NOTE: this field is _independent_ and unrelated to the concepts in channel.proto.
-   * this is controlling the actual hardware frequency the radio is transmitting on.
-   * In a perfect world we would have called it something else (band?) but I forgot to make this change during the big 1.2 renaming.
-   * Most users should never need to be exposed to this field/concept.
-   * A channel number between 1 and 13 (or whatever the max is in the current
-   * region). If ZERO then the rule is "use the old channel name hash based
-   * algorithm to derive the channel number")
-   * If using the hash algorithm the channel number will be: hash(channel_name) %
-   * NUM_CHANNELS (Where num channels depends on the regulatory region).
-   * NUM_CHANNELS_US is 13, for other values see MeshRadio.h in the device code.
-   * hash a string into an integer - djb2 by Dan Bernstein. -
-   * http://www.cse.yorku.ca/~oz/hash.html
-   * unsigned long hash(char *str) {
-   *   unsigned long hash = 5381; int c;
-   *   while ((c = *str++) != 0)
-   *     hash = ((hash << 5) + hash) + (unsigned char) c;
-   *   return hash;
-   * }
+   * Deprecated in favor of LoraConfig.channel_num
    */
-  uint32 channel_num = 1;
+  uint32 channel_num = 1 [deprecated = true];
 
   /*
    * A simple pre-shared key for now for crypto.

--- a/config.options
+++ b/config.options
@@ -1,7 +1,11 @@
 *NetworkConfig.wifi_ssid max_size:33
 *NetworkConfig.wifi_psk max_size:64
+*NetworkConfig.ntp_server max_size:33
 
 # Max of three ignored nodes for our testing
 *LoRaConfig.ignore_incoming max_count:3
 
-*NetworkConfig.ntp_server max_size:33
+*LoRaConfig.tx_power int_size:8
+*LoRaConfig.bandwidth int_size:16
+*LoRaConfig.coding_rate int_size:8
+*LoRaConfig.channel_num int_size:8

--- a/config.proto
+++ b/config.proto
@@ -575,19 +575,11 @@ message Config {
     /*
      * This is controlling the actual hardware frequency the radio is transmitting on.
      * Most users should never need to be exposed to this field/concept.
-     * A channel number between 1 and N (whatever the max is in the current region).
+     * A channel number between 1 and NUM_CHANNELS (whatever the max is in the current region).
      * If ZERO then the rule is "use the old channel name hash based
      * algorithm to derive the channel number")
      * If using the hash algorithm the channel number will be: hash(channel_name) %
      * NUM_CHANNELS (Where num channels depends on the regulatory region).
-     * hash a string into an integer - djb2 by Dan Bernstein. -
-     * http://www.cse.yorku.ca/~oz/hash.html
-     * unsigned long hash(char *str) {
-     *   unsigned long hash = 5381; int c;
-     *   while ((c = *str++) != 0)
-     *     hash = ((hash << 5) + hash) + (unsigned char) c;
-     *   return hash;
-     * }
      */
     uint32 channel_num = 11;
 

--- a/config.proto
+++ b/config.proto
@@ -573,6 +573,25 @@ message Config {
     int32 tx_power = 10;
 
     /*
+     * This is controlling the actual hardware frequency the radio is transmitting on.
+     * Most users should never need to be exposed to this field/concept.
+     * A channel number between 1 and N (whatever the max is in the current region).
+     * If ZERO then the rule is "use the old channel name hash based
+     * algorithm to derive the channel number")
+     * If using the hash algorithm the channel number will be: hash(channel_name) %
+     * NUM_CHANNELS (Where num channels depends on the regulatory region).
+     * hash a string into an integer - djb2 by Dan Bernstein. -
+     * http://www.cse.yorku.ca/~oz/hash.html
+     * unsigned long hash(char *str) {
+     *   unsigned long hash = 5381; int c;
+     *   while ((c = *str++) != 0)
+     *     hash = ((hash << 5) + hash) + (unsigned char) c;
+     *   return hash;
+     * }
+     */
+    uint32 channel_num = 11;
+
+    /*
      * For testing it is useful sometimes to force a node to never listen to
      * particular other nodes (simulating radio out of range). All nodenums listed
      * in ignore_incoming will have packets they send droped on receive (by router.cpp)


### PR DESCRIPTION
`channel_num` defines the LoRa channel frequency.
- one single `lora.channel_num` users can choose for the LoRa frequency (and QR codes);
- simplifies channel logic, making primary/secondary channel roles/index/order irrelevant.

note: when unset device still picks a random `channel_num` based on the primary channel hash (no change).

not a breaking change.