### PR TITLE
Request PortNum for Simulator App

### DIFF
--- a/portnums.proto
+++ b/portnums.proto
@@ -121,6 +121,14 @@ enum PortNum {
   ZPS_APP = 68;
 
   /*
+   * Used to let multiple instances of Linux native applications communicate 
+   * as if they did using their LoRa chip.
+   * Maintained by GitHub user GUVWAF. 
+   * Project files at https://github.com/GUVWAF/Meshtasticator 
+   */
+  SIMULATOR_APP = 69;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/Meshtastic-device/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
I would like to have a dedicated PortNum for simulating multiple instances of the Linux native application. See also my [PR in Meshtastic-device.](https://github.com/meshtastic/Meshtastic-device/pull/1737) 
