### PR TITLE
Add canShutdown and hasWifi

### DIFF
--- a/device_metadata.proto
+++ b/device_metadata.proto
@@ -38,5 +38,5 @@ message DeviceMetadata {
   /*
    * Indicates that the device has an ethernet peripheral
    */
-   bool hasEthernet = 6;
+  bool hasEthernet = 6;
 }

--- a/device_metadata.proto
+++ b/device_metadata.proto
@@ -38,5 +38,5 @@ message DeviceMetadata {
   /*
    * Indicates that the device has an ethernet peripheral
    */
-   bool hasEthernet = 5;
+   bool hasEthernet = 6;
 }

--- a/device_metadata.proto
+++ b/device_metadata.proto
@@ -19,4 +19,14 @@ message DeviceMetadata {
    * Device state version
    */
   uint32 device_state_version = 2;
+
+  /*
+   * Indicates whether the device can shutdown CPU natively or via power management chip
+   */
+  bool canShutdown = 3;
+
+  /*
+   * Indicates that the device has native wifi capabilities
+   */
+  bool hasWifi = 4;
 }

--- a/device_metadata.proto
+++ b/device_metadata.proto
@@ -26,7 +26,17 @@ message DeviceMetadata {
   bool canShutdown = 3;
 
   /*
-   * Indicates that the device has native wifi capabilities
+   * Indicates that the device has native wifi capability
    */
   bool hasWifi = 4;
+
+  /*
+   * Indicates that the device has native bluetooth capability
+   */
+  bool hasBluetooth = 5;
+
+  /*
+   * Indicates that the device has an ethernet peripheral
+   */
+   bool hasEthernet = 5;
 }


### PR DESCRIPTION
This would give any clients the ability to immediately know whether display of the Shutdown button or any Wifi settings is relavent for the connected device.