### PR TITLE
[serial_module] add flag for settings acks for serial messages

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -368,6 +368,11 @@ message ModuleConfig {
      * Existing logging over the Serial Console will still be present
      */
     bool override_console_serial_port = 8;
+
+    /*
+     * Whether to require ACKs for serial packets
+     */
+    bool ack = 9 [default = true];
   }
 
   /*


### PR DESCRIPTION
This PR adds flag which will allow enable(default) or disable acks for Serial module packets.

Related issue: [Related Issue](https://github.com/meshtastic/firmware/issues/5144)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
