### PR TITLE
Add a new port number 75 for the AIRBORNE_APP

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -202,6 +202,11 @@ enum PortNum {
   POWERSTRESS_APP = 74;
 
   /*
+   * Airborne tracking: allow existing systems like OGN or FANET with compact position formats to put those on Meshtantic
+   */
+  AIRBORNE_APP = 75;
+
+  /*
    * Private applications should use portnums >= 256.
    * To simplify initial development and testing you can use "PRIVATE_APP"
    * in your code without needing to rebuild protobuf files (via [regen-protos.sh](https://github.com/meshtastic/firmware/blob/master/bin/regen-protos.sh))


### PR DESCRIPTION
I ask again, after not very succesful yesterday, where I did it at a wrong place, for a new port number.

I propose a new port number for airborne applications like OGN-Tracer or FANET or ADS-L whch have well establilshed compact position packet formats. It is more efficient to put position in this format, which takes like 16 bytes for OGN than use the GPS generic format where many elements are missing like climb rate ro turn rate.

The new port number would allow efficient (low rate) position reports by objects like amateur balloons.

The formatting would be simple: I define ID's for particulat packet type and they would be embedded as a pack of bytes, the decoding of the pack would follow the particular system.

If this gets accepted, I will proceed to define those ID's

Thank you.

BTW. I am beta-receiving Meshtantic on ground receivers of the Open Glider Network (OGN) and I wonder if it would be worth to upload this traffic to a server of yours ?