### PR TITLE
Compress NodeInfoLite bools into a bitfield

### DIFF
--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -9,6 +9,7 @@
 *DeviceState.node_remote_hardware_pins max_count:12
 
 *NodeInfoLite.channel int_size:8
+*NodeInfoLite.bitfield int_size:8
 *NodeInfoLite.hops_away int_size:8
 *NodeInfoLite.next_hop int_size:8
 

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -134,9 +134,14 @@ message NodeInfoLite {
   uint32 channel = 7;
 
   /*
-   * True if we witnessed the node over MQTT instead of LoRA transport
+   * Bitfield to contain 8 1-bit boolean values.
+   * 0 - via_mqtt: True if we witnessed the node over MQTT instead of LoRA transport
+   * 1 - is_favorite: True if node is in our favorites list
+   *        Persists between NodeDB internal clean ups
+   * 2 - is_ignored: True if node is in our ignored list
+   *        Persists between NodeDB internal clean ups
    */
-  bool via_mqtt = 8;
+  uint32 bitfield = 8;
 
   /*
    * Number of hops away from us this node is (0 if direct neighbor)
@@ -144,21 +149,9 @@ message NodeInfoLite {
   optional uint32 hops_away = 9;
 
   /*
-   * True if node is in our favorites list
-   * Persists between NodeDB internal clean ups
-   */
-  bool is_favorite = 10;
-
-  /*
-   * True if node is in our ignored list
-   * Persists between NodeDB internal clean ups
-   */
-  bool is_ignored = 11;
-
-  /*
    * Last byte of the node number of the node that should be used as the next hop to reach this node.
    */
-  uint32 next_hop = 12;
+  uint32 next_hop = 10;
 }
 
 /*


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?

<!-- Please remove or replace the issue url -->

> [Related Issue Meshtastic#6427](https://github.com/meshtastic/firmware/issues/6427)

This PR proposes to squash 3 bytes into 1 and allows up to 5 new boolean flags "for free." This will save 2 bytes per NodeInfoLite, or about 200 - 500 bytes in memory for most devices.

I'm new to this, so the process for updating the protobufs and then refactoring the firmware is not clear to me. Please let me know if there is something else I must do before applying the associated refactor to the firmware repo.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
