### PR TITLE
Encode non-present battery somehow

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -13,9 +13,9 @@ option swift_prefix = "";
  */
 message DeviceMetrics {
   /*
-   * 0-100 (>100 means powered)
+   * 0-100 (>100 means powered, -1 means not connected)
    */
-  optional uint32 battery_level = 1;
+  optional int32 battery_level = 1;
 
   /*
    * Voltage measured


### PR DESCRIPTION
This is a small PR along with https://github.com/meshtastic/firmware/pull/7048 to encode battery levels as -1 when the battery is not detected.

This PR by itself doesn't do much, other than modifying the comment in the `proto` and changing battery level to `int32_t`.


