### PR TITLE
Add New device Retia.io Nibble Connect to HardwareModel list

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -759,6 +759,11 @@ enum HardwareModel {
    */
   GAT562_MESH_TRIAL_TRACKER = 104;
 
+  /**
+   * Retia.io Nibble Connect
+   */
+  NIBBLE_CONNECT = 106;
+
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
Add New Device Retia.io Nibble Connect to Hardware Model list

# What does this PR do?

Adding an entry in the HardwareModel enum for new device

> [Related Issue](https://github.com/meshtastic/protobufs/issues/7062)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions
