### PR TITLE
Add temperature offset to environment module config

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -608,6 +608,12 @@ message ModuleConfig {
      * Enable/Disable the health telemetry module on-device display
      */
     bool health_screen_enabled = 13;
+
+    /*
+     * Temperature offset in Celsius to apply to sensor readings
+     * Positive values increase reported temperature, negative values decrease it
+     */
+    float environment_temperature_offset = 14;
   }
 
   /*


### PR DESCRIPTION
# What does this PR do?
Introduced a new float field 'environment_temperature_offset' to the EnvironmentConfig message, allowing adjustment of reported sensor temperature readings by a specified offset in Celsius.

> [Related Issue](https://github.com/meshtastic/firmware/issues/7093)

## Checklist before merging

- [x] All top level messages commented
