### PR TITLE
To add VN_433 and VN_923 for Vietnam

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -930,6 +930,14 @@ message Config {
        * Kazakhstan 863MHz
        */
       KZ_863 = 24;
+      /*
+       * Vietnam 433Mhz
+       */
+      VN_433 = 25;
+      /*
+       * Vietnam 923Mhz
+       */
+      VN_923 = 26; 
     }
 
     /*


### PR DESCRIPTION
This PR is to add VN_433 and VN_923 for Vietnam.

Main document: https://vanban.chinhphu.vn/default.aspx?pageid=27160&docid=204286
In Page 16: https://datafiles.chinhphu.vn/cpp/files/vbpq/2021/10/08-btttt.signed.pdf
The accepted frequencies by Vietnam government is
- Item 39: 433.05 - 434.79 MHz <=25 mW ERP
- Item 45: 920 - 923 MHz <=25 mW ERP

Thanks a lot and have a nice day.
