### PR TITLE
Mark configs as deprecated that are no longer used.

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -698,7 +698,7 @@ message Config {
      * If this is set, the displayed compass will always point north. if unset, the old behaviour
      * (top of display is heading direction) is used.
      */
-    bool compass_north_top = 4;
+    bool compass_north_top = 4 [deprecated = true];
 
     /*
      * Flip screen vertically, for cases that mount the screen upside down

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -700,13 +700,13 @@ message ModuleConfig {
     /*
      * Enable/disable CannedMessageModule.
      */
-    bool enabled = 9;
+    bool enabled = 9 [deprecated = true];
 
     /*
      * Input event origin accepted by the canned message module.
      * Can be e.g. "rotEnc1", "upDownEnc1", "scanAndSelect", "cardkb", "serialkb", or keyword "_any"
      */
-    string allow_input_source = 10;
+    string allow_input_source = 10 [deprecated = true];
 
     /*
      * CannedMessageModule also sends a bell character with the messages.


### PR DESCRIPTION
With the 2.7 work, these configs are not used at all.