### PR TITLE
Fix JSR & NPM build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ts_code
+      - name: Remove package.json
+        run: rm package.json
       - name: Set up Deno
         uses: denoland/setup-deno@main
         with:


### PR DESCRIPTION
Follow-up to #764:

* Make NPM build depend on the `codegen` step so that the assets are actually available
* Remove `package.json` before JSR publish so it doesn't interfere there 