### PR TITLE
Point to the correct JS file

### DIFF
--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -8,9 +8,9 @@
     "access": "public"
   },
   "type": "module",
-  "main": "./dist/mod.mjs",
-  "module": "./dist/mod.mjs",
-  "types": "./dist/mod.d.mts",
+  "main": "./dist/mod.js",
+  "module": "./dist/mod.js",
+  "types": "./dist/mod.d.ts",
   "dependencies": {
     "@bufbuild/protobuf": "^2.2.3"
   },


### PR DESCRIPTION
It turns out we generate a `.js` file, not `.mjs`.