### PR TITLE
NPM Publish only if new

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,9 +92,9 @@ jobs:
       - name: Build JavaScript module
         run: npm run build
       - name: Publish NPM package
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
 
   publish-cargo:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Right now the `next` workflow is to run the publishing action on every push. This means there are many publishing attempts where version number hasn't changed.

With NPM, these publishing attempts will fail with error like:
```
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@meshtastic%2fprotobufs - You cannot publish over the previously published versions: 2.7.0.
```

This PR changes to the [npm-publish](https://github.com/JS-DevTools/npm-publish) action which at least claims to check versions before attempting to publish.