### PR TITLE
Add ignore option for FILE_OPTION_CHANGED

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -6,6 +6,8 @@ build:
 breaking:
   use:
     - FILE
+  ignore:
+    - FILE_OPTION_CHANGED
 lint:
   ignore_only:
     PACKAGE_DEFINED:


### PR DESCRIPTION
Explicitly ignore that we changed the `java_package` - we know, bro, it was on purpose.

This is to handle the `buf` build errors introduced in #788.
