### PR TITLE
Client notification messages for different public key and failed PKI decryption

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -69,6 +69,7 @@
 *KeyVerification.hash1 max_size:32
 *KeyVerification.hash2 max_size:32
 
+*DifferentPublicKey.public_key max_size:32
 
 # MyMessage.name         max_size:40 
 # or fixed_length or fixed_count, or max_count

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2022,6 +2022,8 @@ message ClientNotification {
     KeyVerificationFinal key_verification_final = 13;
     DuplicatedPublicKey duplicated_public_key = 14;
     LowEntropyKey low_entropy_key = 15;
+    DifferentPublicKey different_public_key = 16;
+    PKIDecryptionFailed pki_decryption_failed = 17;
   }
 }
 
@@ -2042,6 +2044,32 @@ message KeyVerificationFinal {
 }
 message DuplicatedPublicKey {}
 message LowEntropyKey {}
+
+/* 
+ * Client notifcation message for when a different public key than the currently stored one of a remote node has been received.
+ */
+message DifferentPublicKey {
+  /*
+   * Node number of the remote node we received a different public key from.
+   */ 
+  uint32 node_num = 1;
+
+  /*
+   * The different public key we received from the remote node.
+   */ 
+  bytes public_key = 2;
+}
+
+/*
+ * Client notification message for when we receive a PKI-encrypted packet from a remote node we couldn't decrypt,
+ * while we did have a public key for the node.
+ */ 
+message PKIDecryptionFailed {
+  /*
+   * Node number of the remote node we received an undecryptable PKI packet from.
+   */ 
+  uint32 node_num = 1;
+}
 
 /*
  * Individual File info for the device


### PR DESCRIPTION
For consideration to improve the UX when PKI fails after a remote node changed their keys (https://github.com/meshtastic/firmware/issues/8211).

The idea is that when we receive a NodeInfo with a different public key than the device has currently stored in its NodeDB, we do not simply ignore it like currently, but we inform the client about this. The client could then either already ask the user if it would like to accept this different key (by importing the same node as Shared Contact with new key), *or* cache this different public key to be used when the node is receiving a PKI encrypted packet it couldn't decrypt (this is the less "spammy" approach). If it did not yet receive a different public key when the latter happens, it could also ask the user if it wants to clear the currently stored key, such that it is able to accept a new one.
