### PR TITLE
Add rx_frequency_error to meshpacket

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1499,6 +1499,11 @@ message MeshPacket {
    * Indicates which transport mechanism this packet arrived over
    */
   TransportMechanism transport_mechanism = 21;
+
+  /*
+   * Contains the float value returned by lora.getFrequencyError()
+   */
+  float rx_frequency_error = 22;
 }
 
 /*


### PR DESCRIPTION
Radiolib includes the lora.getFrequencyError() function to return the offset from expected frequency center. This can be added to meshpacket and used to help debug mesh problems.