### PR TITLE
Add EU_433_V2 entry, to facilitate transition

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -924,6 +924,15 @@ message Config {
        * Brazil 902MHz
        */
       BR_902 = 26;
+
+      /*
+       * European Union 433mhz
+       * When originally defined, the EU_433 frequency band definition was off
+       * by a small amount. This is a transitional entry communities can use
+       * to coordinate their switch to the correct values.
+       */
+      EU_433_V2 = 27;
+
     }
 
     /*


### PR DESCRIPTION
When EU_433 was originally defined in firmware, the band definition was off by a small amount.

EU_433 is now in widespread use, so changing that definition is a breaking change. This patch introduces an alternative.

In order to facilitate communities making a planned transition between the frequency bands at a coordinated time, this patch introduces EU_433_V2 . Selecting EU_433_V2 will configure a Meshtastic device with the corrected band definitions.

The overall plan for the transition would look something like this:
1. Introduce EU_433_V2 to protobufs, firmware, and apps
2. Announce that communities have the option of making a transition to the corrected band, and encourage communities to coordinate a transition at a time that works for them.
3. After many months, we reach a time where the supermajority of affected communities have made a transition to the new band
4. We change app behaviour, making EU_433_V2 as the prominent choice over EU_433
5. We monitor complaints about band options and communities with a lagging transition.
6. We remove the original EU_433 from the apps


See also: 
https://github.com/meshtastic/firmware/pull/2696
