### PR TITLE
Add unencrypted payloads

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1106,6 +1106,11 @@ message Data {
    * Bitfield for extra flags. First use is to indicate that user approves the packet being uploaded to MQTT.
    */
   optional uint32 bitfield = 9;
+
+  /*
+   * Magic number used to verify that a decoded packet is actually supposed to be unencrypted
+   */
+  uint32 tx_unencrypted = 11;
 }
 
 /*


### PR DESCRIPTION
Add field to denote that a payload is supposed to be sent unencrypted. Support field for https://github.com/meshtastic/firmware/pull/8454.