### PR TITLE
Add Belarus Frequencies

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -924,6 +924,11 @@ message Config {
        * Brazil 902MHz
        */
       BR_902 = 26;
+
+      /*
+       * Belarus 433MHz
+       */
+      BY = 27;
     }
 
     /*


### PR DESCRIPTION
This PR adds support for a new regional frequency configuration for Belarus. The change introduces the BY (Belarus) region with 433MHz frequency support to the LoRa region configuration enumeration.

Added BY region enum value (27) for Belarus 433MHz frequency band

> [Related Issue](https://github.com/meshtastic/Meshtastic-Android/pull/3562)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
