### PR TITLE
Add WISMESH_TAP_V2 and RAK3401 hardware models to mesh.proto

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -816,6 +816,16 @@ enum HardwareModel {
   THINKNODE_M3 = 115;
 
   /*
+   * RAK WISMESH_TAP_V2 with ESP32-S3 CPU
+   */
+  WISMESH_TAP_V2 = 116;
+
+  /*
+   * RAK3401
+   */
+  RAK3401 = 117;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request adds support for two new hardware models to the `HardwareModel` enum in the `meshtastic/mesh.proto` file. These changes expand the protocol to recognize additional device types.

Hardware model additions:

* Added `WISMESH_TAP_V2` (RAK WISMESH_TAP_V2 with ESP32-S3 CPU) to the `HardwareModel` enum.
* Added `RAK3401` to the `HardwareModel` enum.