### PR TITLE
Rak3112 support

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -826,6 +826,11 @@ enum HardwareModel {
   RAK3401 = 117;
 
   /*
+   * RAKwireless WisBlock Core RAK3112 https://docs.rakwireless.com/product-categories/wisduo/rak3112-module/overview/
+   */
+  RAK3112 = 118;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do?
Adds the new Rak3112 module to meshtastic's platformIO ecosystem.

## Checklist before merging
- [x] All top level messages commented
- [x] All enum members have unique descriptions