### PR TITLE
Add set_promiscuous variant to ToRadio message

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2225,6 +2225,14 @@ message ToRadio {
      * Heartbeat message (used to keep the device connection awake on serial)
      */
     Heartbeat heartbeat = 7;
+    
+    /*
+     * Set or clear promiscuous capture mode for LoRa RX.
+     * If true, the device will forward all received LoRa packets to FromRadio as encrypted MeshPacket payloads,
+     * and will avoid additionally sending the decrypted copies. ToRadio will also skip overwriting the from address.
+     * This is primarily intended for virtual nodes that want to handle the packet protocol directly via serial.
+     */
+    bool set_promiscuous = 8;
   }
 }
 


### PR DESCRIPTION
Adds an additional ToRadio variant for setting promiscuous mode on the serial connection.

This mode will enable Receiving and Sending unaltered (encrypted) packets by virtual nodes.

Firmware PR https://github.com/meshtastic/firmware/pull/8596