### PR TITLE
Describe further the "to" field in MeshPacket

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1371,6 +1371,10 @@ message MeshPacket {
 
   /*
    * The (immediate) destination for this packet
+   * If the value is 4,294,967,295 (maximum value of an unsigned 32bit integer), this indicates that the packet was
+   * not destined for a specific node, but for a channel as indicated by the value of `channel` below.
+   * If the value is another, this indicates that the packet was destined for a specific
+   * node (i.e. a kind of "Direct Message" to this node) and not broadcast on a channel.
    */
   fixed32 to = 2;
 


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

# What does this PR do?
Enhances the docs describing the "to" field in MeshPacket, and the special case of when it is set top the maximum value permitted by a 32 bit integer.

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/protobufs/issues/0)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions


### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.
