### PR TITLE
Describe further the reply_id and emoji fields in Data struct of MeshPacket

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1107,13 +1107,15 @@ message Data {
   fixed32 request_id = 6;
 
   /*
-   * If set, this message is intened to be a reply to a previously sent message with the defined id.
+   * If this field is 0, this message is a new message and not a reply.
+   * If this field is non-zero, this message is a reply to a previously sent message whose id is reply_id.
+   * Reply messages can be a text reply (emoji == 0), or an emoji reply (emoji == 1).
    */
   fixed32 reply_id = 7;
 
   /*
-   * Defaults to false. If true, then what is in the payload should be treated as an emoji like giving
-   * a message a heart or poop emoji.
+   * If set to 0 this message is a normal text message, like a chat message.
+   * If set to 1 this message is an emoji reply to an earlier message, like giving a message a heart or poop emoji.
    */
   fixed32 emoji = 8;
 


### PR DESCRIPTION
Added further comments to help interpret those two fields of the Data struct, based on what I learned implementing code using it.

# What does this PR do?

Add comments for docs.

> [Related Issue](https://github.com/meshtastic/protobufs/issues/0)

## Checklist before merging

- [ ] All top level messages commented
- [ ] All enum members have unique descriptions


### New Hardware Model Acceptance Policy

Due to limited availability and ongoing support, new Hardware Models will only be accepted from [Meshtastic Backers and Partners](https://meshtastic.com/). The Meshtastic team reserves the right to make exceptions to this policy.

#### Alternative for Community Contributors

You are welcome to use one of the existing DIY hardware models in your PlatformIO environment and create a pull request in the firmware project. Please note the following conditions:

- The device will **not** be officially supported by the core Meshtastic team.
- The device will **not** appear in the [Web Flasher](https://flasher.meshtastic.org/) or Github release assets.
- You will be responsible for ongoing maintenance and support.
- Community-contributed / DIY hardware models are considered experimental and will likely have limited or no testing.

#### Getting Official Support

To have your hardware model officially supported and included in the Meshtastic ecosystem, consider becoming a Meshtastic Backer or Partner. Visit [meshtastic.com](https://meshtastic.com/) for more information about partnership opportunities.
