### PR TITLE
Added EdgeFastLow-settings for modem

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -978,6 +978,13 @@ message Config {
        * It is not legal to use in all regions due to this wider bandwidth.
        */
       SHORT_TURBO = 8;
+
+      /*
+       * Edge Fast Low
+       * Designed to work in very harsh conditions when a lot of radio interference is present
+       * Useful when the used LoRa frequency band is very congested and full of other traffic
+       */
+      EDGE_FAST_LOW = 9;
     }
 
     /*


### PR DESCRIPTION
I've added EdgeFastLow -settings for LoRa-modem (BW 62, SF 8, CR 8). Cross-checked the new setting between different points/files in firmware, web and Android-application. Added to different language translations, too.

More info here: https://www.meshhubmids.com/edge.html
