### PR TITLE
Deprecate LONG_SLOW preset

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -938,8 +938,9 @@ message Config {
 
       /*
        * Long Range - Slow
+       * Deprecated in 2.7: Unpopular slow preset.
        */
-      LONG_SLOW = 1;
+      LONG_SLOW = 1 [deprecated = true];
 
       /*
        * Very Long Range - Slow


### PR DESCRIPTION
Mark LONG_SLOW as deprecated in the config.proto file.


## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

