### PR TITLE
Adding ADA4026 Soil Moisture Sensor

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -795,6 +795,7 @@ enum TelemetrySensorType {
    * BH1750 light sensor
    */
   BH1750 = 45;
+
   /*
    * ADA4026 Soil Moisture Sensor
    */

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -795,6 +795,10 @@ enum TelemetrySensorType {
    * BH1750 light sensor
    */
   BH1750 = 45;
+  /*
+   * ADA4026 Soil Moisture Sensor
+   */
+  ADA4026 = 46;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?
I added ADA4026 to the TelemetrySensorType enum so that I can add support for the sensor in the meshtastic/firmware repo. 
<img width="480" height="360" alt="image" src="https://github.com/user-attachments/assets/4e2a7327-7fa9-4f52-b50d-3ea2cfdd250b" />

Should I wait to create a pr for the sensor.cpp and .h files within the meshtastic/firmware repo until these changes get merged?



## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

