### PR TITLE
Add chain_count field to mesh.proto

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1237,11 +1237,11 @@ message StoreForwardPlusPlus {
    * The receive time of the message in question
    */
   uint32 encapsulated_rxtime = 9;
-  
+
   /*
    * Used in a LINK_REQUEST to specify the message X spots back from head
    */
-   uint32 chain_count = 10;
+  uint32 chain_count = 10;
 }
 
 /*


### PR DESCRIPTION
This field will allow partial syncing of SF++ nodes, to avoid the deluge of traffic when bringing up a new SF++ satellite node.