### PR TITLE
Add MINIMESH_LITE=212 to HardwareModel enum

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -841,6 +841,11 @@ enum HardwareModel {
   THINKNODE_M6 = 120;
 
   /*
+   * Minimesh Lite
+   */
+  MINIMESH_LITE = 212;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do?

Adds a new DIY Hardware Model enum for the Minimesh Lite device.

- **Enum value:** `MINIMESH_LITE = 212`  
- **Purpose:** Allow DIY Minimesh Lite users to see the correct device name in firmware and apps.  
- This is a community contribution / DIY hardware model and is considered experimental.

---

## Related Issue

No official issue, community contribution.

---

## Checklist before merging

- [x] All top level messages commented  
- [x] All enum members have unique descriptions  

---

## New Hardware Model Acceptance Policy

This is a community-contributed DIY hardware model. It is **experimental** and will **not** be officially supported by the core Meshtastic team.  

- It will **not** appear in Web Flasher or GitHub release assets.  
- Ongoing maintenance and support are the responsibility of the contributor.

---

## Alternative for Community Contributors

Users can now use `MINIMESH_LITE` in their PlatformIO environment with this protobuf update.
