### PR TITLE
hop decrement skipping flag

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1107,6 +1107,12 @@ message Config {
      * Sets the ok_to_mqtt bit on outgoing packets
      */
     bool config_ok_to_mqtt = 105;
+
+    /*
+     * If true, skip decrementing hop_limit when forwarding packets.
+     * This allows packets to travel further through the mesh network.
+     */
+    bool skip_hop_decrement = 106;
   }
 
   message BluetoothConfig {


### PR DESCRIPTION
# What does this PR do?

Adds support for the option to skip hop decrementing on all device roles.

Required by: https://github.com/meshtastic/firmware/pull/9102

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
