### PR TITLE
Add StatusMessage message and portnum

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -74,6 +74,7 @@
 *StoreForwardPlusPlus.root_hash max_size:32
 *StoreForwardPlusPlus.message max_size:240
 
+*StatusMessage.status max_size:80
 
 # MyMessage.name         max_size:40 
 # or fixed_length or fixed_count, or max_count

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1297,6 +1297,13 @@ message Waypoint {
 }
 
 /*
+ * Message for node status
+ */
+message StatusMessage {
+  string status = 1;
+}
+
+/*
  * This message will be proxied over the PhoneAPI for the client to deliver to the MQTT server
  */
 message MqttClientProxyMessage {

--- a/meshtastic/module_config.options
+++ b/meshtastic/module_config.options
@@ -27,3 +27,5 @@
 *DetectionSensorConfig.monitor_pin int_size:8
 *DetectionSensorConfig.name max_size:20
 *DetectionSensorConfig.detection_trigger_type max_size:8
+
+*StatusMessage.node_status max_size:80

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -762,6 +762,16 @@ message ModuleConfig {
   }
 
   /*
+   * StatusMessage config - Allows setting a status message for a node to periodically rebroadcast
+   */
+  message StatusMessageConfig {
+    /*
+     * The actual status string
+     */
+    string node_status = 1;
+  }
+
+  /*
    * TODO: REPLACE
    */
   oneof payload_variant {
@@ -829,6 +839,11 @@ message ModuleConfig {
      * TODO: REPLACE
      */
     PaxcounterConfig paxcounter = 13;
+
+    /*
+     * TODO: REPLACE
+     */
+    StatusMessageConfig statusmessage = 14;
   }
 }
 

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -143,6 +143,14 @@ enum PortNum {
   STORE_FORWARD_PLUSPLUS_APP = 35;
 
   /*
+   * Node Status module
+   * ENCODING: protobuf
+   * This module allows setting an extra string of status for a node.
+   * Broadcasts on change and on a timer, possibly once a day.
+   */
+  NODE_STATUS_APP = 36;
+
+  /*
    * Provides a hardware serial interface to send and receive from the Meshtastic network.
    * Connect to the RX/TX pins of a device with 38400 8N1. Packets received from the Meshtastic
    * network is forwarded to the RX pin while sending a packet to TX will go out to the Mesh network.


### PR DESCRIPTION
Adds a node status message, payload, and config message. Should allow users to move their status messages out of the node longname.