### PR TITLE
Bring back LongSlow

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -938,9 +938,8 @@ message Config {
 
       /*
        * Long Range - Slow
-       * Deprecated in 2.7: Unpopular slow preset.
        */
-      LONG_SLOW = 1 [deprecated = true];
+      LONG_SLOW = 1;
 
       /*
        * Very Long Range - Slow


### PR DESCRIPTION
<!-- Describe what you are intending to change -->

Brings back the LONG_SLOW preset as it is useful in areas with fewer nodes and very low density.

<!-- Please remove or replace the issue url -->

> [Related Issue](https://github.com/meshtastic/protobufs/issues/836)
