### PR TITLE
Add VL53L0 distance sensor.

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -671,6 +671,11 @@ message SensorConfig {
    * SHTXX temperature and relative humidity sensor configuration
    */
   SHTXX_config shtxx_config = 4;
+
+  /*
+   * VL53L0X Distance Sensor configuration
+   */
+  VL53L0X_config vl53l0x_config = 5;
 }
 
 message SCD4X_config {
@@ -759,4 +764,11 @@ message SHTXX_config {
    * Accuracy mode (0 = low, 1 = medium, 2 = high)
    */
   optional uint32 set_accuracy = 1;
+}
+
+message VL53L0X_config {
+  /*
+   * Ranging mode (0 = default, 1 = long range, 2 = high speed,3 = high accuracy)
+   */
+  optional uint32 ranging_mode = 1;
 }

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -881,6 +881,11 @@ enum TelemetrySensorType {
    * DS248X Bridge for one-wire temperature sensors
    */
   DS248X = 51;
+
+  /*
+   * VL53L0X distance, sensor
+   */
+  VL53L0X = 52;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -937,3 +937,17 @@ message SEN5XState {
    */
   optional fixed64 voc_state_array = 6;
 }
+
+message VL53L0XState {
+  enum RangingMode {
+    Default = 0;
+    LongRange = 1;
+    HighSpeed = 2;
+    HighAccuracy = 3;
+  }
+
+  /*
+   * Current Ranging Mode
+   */
+  RangingMode mode = 1;
+}


### PR DESCRIPTION
Updated protobuf TelemetrySensorType to define VL53L0.

Related firmware pull request [Add VL53L0 distance sensor.](https://github.com/meshtastic/firmware/pull/9706#top)