### PR TITLE
feat(config): add rsyslog_level field to NetworkConfig for syslog severity filtering

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -579,6 +579,54 @@ message Config {
     bool ipv6_enabled = 11;
 
     /*
+     * Syslog log level to control which messages are sent to the rsyslog server.
+     * Only messages at or above this level will be forwarded.
+     * Values match LogRecord.Level for consistency. Default (UNSET) treats as INFO.
+     */
+    enum LogLevel {
+      /*
+       * No level set, firmware defaults to INFO
+       */
+      LOG_UNSET = 0;
+
+      /*
+       * Trace level (most verbose)
+       */
+      LOG_TRACE = 5;
+
+      /*
+       * Debug level
+       */
+      LOG_DEBUG = 10;
+
+      /*
+       * Informational
+       */
+      LOG_INFO = 20;
+
+      /*
+       * Warning conditions
+       */
+      LOG_WARNING = 30;
+
+      /*
+       * Error conditions
+       */
+      LOG_ERROR = 40;
+
+      /*
+       * Critical conditions
+       */
+      LOG_CRITICAL = 50;
+    }
+
+    /*
+     * Minimum severity level of log messages to send to the rsyslog server.
+     * Messages below this level are filtered out. Default (UNSET) sends INFO and above.
+     */
+    LogLevel rsyslog_level = 12;
+
+    /*
      * Available flags auxiliary network protocols
      */
     enum ProtocolFlags {


### PR DESCRIPTION
## Summary

- Add `LogLevel` enum to `NetworkConfig` with values matching `LogRecord.Level` (UNSET=0, TRACE=5, DEBUG=10, INFO=20, WARNING=30, ERROR=40, CRITICAL=50)
- Add `rsyslog_level` field (tag 12) to `NetworkConfig` to allow users to configure the minimum syslog severity level
- Default (UNSET) is treated as INFO by the firmware, filtering out DEBUG messages

## Motivation

Currently the Meshtastic firmware forwards all log messages to the configured rsyslog server with no way to filter by severity. This generates significant syslog traffic, especially from DEBUG messages that are rarely needed in production.

This protobuf change adds the configuration field needed to support severity-based filtering. The companion firmware PR (meshtastic/firmware) implements the filtering logic using the existing `Syslog::logMask()` mechanism.

## Backwards Compatibility

- The new field defaults to 0 (LOG_UNSET), which the firmware treats as INFO level
- Existing devices that upgrade will automatically filter out DEBUG syslog messages (reducing noise)
- No breaking changes to existing fields or wire format

## Test plan

- [ ] Verify protobuf generation succeeds with the new enum and field
- [ ] Verify firmware builds with the generated nanopb files
- [ ] Test on RAK4631 Ethernet Gateway: confirm DEBUG messages are filtered by default
- [ ] Test setting rsyslog_level to DEBUG: confirm all messages forwarded
- [ ] Test setting rsyslog_level to WARNING: confirm only WARNING, ERROR, CRITICAL forwarded
