### PR TITLE
Make PM metrics float 

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -247,17 +247,17 @@ message AirQualityMetrics {
   /*
    * Concentration Units Standard PM1.0 in ug/m3
    */
-  optional uint32 pm10_standard = 1;
+  optional float pm10_standard = 1;
 
   /*
    * Concentration Units Standard PM2.5 in ug/m3
    */
-  optional uint32 pm25_standard = 2;
+  optional float pm25_standard = 2;
 
   /*
    * Concentration Units Standard PM10.0 in ug/m3
    */
-  optional uint32 pm100_standard = 3;
+  optional float pm100_standard = 3;
 
   /*
    * Concentration Units Environmental PM1.0 in ug/m3
@@ -337,7 +337,7 @@ message AirQualityMetrics {
   /*
    * Concentration Units Standard PM4.0 in ug/m3
    */
-  optional uint32 pm40_standard = 19;
+  optional float pm40_standard = 19;
 
   /*
    * 4.0um Particle Count in #/0.1l


### PR DESCRIPTION
Many new PM sensors support floats for PM readings. This increases payload size with the varint-to-float move, but the gain in precision is worth it for me. Note that I am not changing the pm_environmental, because the only sensor that provides that is the PMS, and they are ints.

Since this is a breaking change, I let it to @caveman99 to see if it can be included in future versions where other things are refactored.