### PR TITLE
feat: add DS18B20 1-Wire sensor support

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -620,6 +620,50 @@ message ModuleConfig {
   }
 
   /*
+   * DS18B20 1-Wire sensor configuration.
+   */
+  message DS18B20Config {
+    /*
+     * GPIO pin for the DS18B20 1-Wire sensor bus. 0 = disabled.
+     * Set via CLI to activate DS18B20 support on any pin.
+     */
+    uint32 pin = 1;
+
+    /*
+     * Which value the legacy EnvironmentMetrics.temperature scalar reports.
+     */
+    enum TemperatureMode {
+      /*
+       * Report the temperature of the first sensor (index 0, sorted by ROM code). Default.
+       */
+      FIRST = 0;
+      /*
+       * Report the average temperature across all connected sensors.
+       */
+      AVERAGE = 1;
+      /*
+       * Report the minimum temperature across all connected sensors.
+       */
+      MIN = 2;
+      /*
+       * Report the maximum temperature across all connected sensors.
+       */
+      MAX = 3;
+    }
+
+    /*
+     * Selects what value the legacy EnvironmentMetrics.temperature scalar reports.
+     */
+    TemperatureMode mode = 2;
+
+    /*
+     * When true, DS18B20 readings beyond the first packet are broadcast over LoRa mesh.
+     * When false (default), extra sensor chunks are sent only to the connected phone/client.
+     */
+    bool mesh_enabled = 3;
+  }
+
+  /*
    * Configuration for both device and environment metrics
    */
   message TelemetryConfig {
@@ -707,6 +751,11 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
+
+    /*
+     * DS18B20 1-Wire sensor configuration. Pin, temperature mode, and mesh broadcast control.
+     */
+    DS18B20Config ds18b20 = 16;
   }
 
   /*

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -1,6 +1,7 @@
 # options for nanopb
 # https://jpa.kapsi.fi/nanopb/docs/reference.html#proto-file-options
 
+*EnvironmentMetrics.ds18b20_readings max_count:16
 *EnvironmentMetrics.iaq int_size:16
 *EnvironmentMetrics.wind_direction int_size:16
 *EnvironmentMetrics.soil_moisture int_size:8

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -153,6 +153,26 @@ message EnvironmentMetrics {
    * Soil temperature measured (*C)
    */
   optional float soil_temperature = 22;
+
+  /*
+   * DS18B20 1-Wire temperature sensor readings
+   */
+  repeated DS18B20Reading ds18b20_readings = 23;
+}
+
+/*
+ * A single DS18B20 1-Wire temperature sensor reading with its unique ROM code
+ */
+message DS18B20Reading {
+  /*
+   * 32-bit FNV-1a hash of the 64-bit 1-Wire ROM code — stable, compact identifier per sensor
+   */
+  fixed32 device_id = 1;
+
+  /*
+   * Temperature in degrees Celsius
+   */
+  float temperature = 2;
 }
 
 /*
@@ -871,6 +891,11 @@ enum TelemetrySensorType {
    * SHT family of sensors for temperature and humidity
    */
   SHTXX = 50;
+
+  /*
+   * Dallas/Maxim DS18B20 1-Wire digital thermometer
+   */
+  DS18B20 = 51;
 }
 
 /*


### PR DESCRIPTION
## Summary

Adds protobuf definitions for Dallas/Maxim DS18B20 1-Wire digital thermometer support in Meshtastic firmware.

### Changes

**`meshtastic/telemetry.proto`**
- New `DS18B20Reading` message:
  ```proto
  message DS18B20Reading {
    fixed32 device_id = 1;  // FNV-1a 32-bit hash of 64-bit 1-Wire ROM code
    float temperature = 2;  // Temperature in degrees Celsius
  }
  ```
- `repeated DS18B20Reading ds18b20_readings = 23` added to `EnvironmentMetrics`
- `DS18B20 = 51` added to `TelemetrySensorType` enum

**`meshtastic/module_config.proto`**
- New `DS18B20Config` sub-message inside `TelemetryConfig` (field 16):
  ```proto
  message DS18B20Config {
    uint32 pin = 1;           // GPIO pin for 1-Wire bus (0 = disabled)
    TemperatureMode mode = 2; // FIRST | AVERAGE | MIN | MAX
    bool mesh_enabled = 3;    // Broadcast overflow chunks over LoRa mesh
  }
  ```

**`meshtastic/telemetry.options`**
- `*EnvironmentMetrics.ds18b20_readings max_count:16` — nanopb static array sizing

### Design notes

- `fixed32 device_id` uses FNV-1a 32-bit hash of the full 64-bit ROM code — stable across reboots, saves 4 bytes per reading vs `fixed64`, collision probability ~0.0001% for 100 sensors
- Field 16 in `TelemetryConfig` is used for `DS18B20Config`; `air_quality_screen_enabled` occupies field 15
- `DS18B20 = 51` in the sensor type enum (50 was unassigned at time of authoring)

Related firmware PR: meshtastic/firmware#9995