### PR TITLE
network: add udp toggles to control rebroadcast

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -592,6 +592,16 @@ message Config {
        */
       UDP_BROADCAST = 0x0001;
     }
+
+    /*
+     * Enable rebroadcasting mesh packets via UDP
+     */
+    bool udp_rebroadcast = 12;
+
+    /*
+     * Enable skipping LoRa for locally generated packets sent via UDP
+     */
+    bool udp_skip_lora = 13;
   }
 
   /*


### PR DESCRIPTION
Add two new toggles to the Network section:

- udp_rebroadcast: Rebroadcasting mesh packets via UDP

- udp_skip_lora: Skip LoRa for locally generated packets via UDP

This enables us to implement https://github.com/meshtastic/firmware/pull/9999 without relying on roles.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

