### PR TITLE
Added description of special SNR values in RouteDiscovery

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -975,6 +975,10 @@ message RouteDiscovery {
 
   /*
    * The list of SNRs (in dB, scaled by 4) in the route towards the destination.
+   * Special values (ouside normal SNR range) are used as flags:
+   * -128 : Unknonw SNR
+   * -127 : MQTT hop
+   *  127 : UDP hop
    */
   repeated int32 snr_towards = 2;
 
@@ -985,6 +989,10 @@ message RouteDiscovery {
 
   /*
    * The list of SNRs (in dB, scaled by 4) in the route back from the destination.
+   * Special values (ouside normal SNR range) are used as flags:
+   * -128 : Unknonw SNR
+   * -127 : MQTT hop
+   *  127 : UDP hop
    */
   repeated int32 snr_back = 4;
 }


### PR DESCRIPTION
…op types

<!-- Describe what you are intending to change -->

This PR introduces a description (comments) on SNR special values that work as flags in the RouteDiscovery messages.
It was requested in the discussion for firmware issue 9013 (make MQTT and UDP hops clear in the traceroute displays)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

(no changes were made)
