### PR TITLE
feat: add PICO2_W5500_E22 HardwareModel (ID 129)

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -878,6 +878,9 @@ enum HardwareModel {
   /* Seeed studio T1000-E Pro tracker card. NRF52840 w/ LR2021 radio, GPS, button, buzzer, and sensors. */
   TRACKER_T1000_E_PRO = 128;
 
+  /* Raspberry Pi Pico 2 (RP2350) with WIZnet W5500 Ethernet and EBYTE E22-900M30S SX1262 LoRa */
+  PICO2_W5500_E22 = 129;
+
   /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.


### PR DESCRIPTION
## Summary

Adds a new `HardwareModel` enum entry for the **Raspberry Pi Pico 2 + WIZnet W5500 + EBYTE E22-900M30S** board variant.

- **ID:** 129
- **MCU:** RP2350 (Raspberry Pi Pico 2)
- **Radio:** EBYTE E22-900M30S (SX1262) — 30 dBm, 900 MHz
- **Networking:** WIZnet W5500 Ethernet (onboard, SPI)
- **Variant PR:** meshtastic/firmware#10135

## Hardware Details

| Component | Part |
|-----------|------|
| MCU | RP2350 @ 150 MHz (dual Cortex-M33) |
| LoRa | SX1262 via EBYTE E22-900M30S (+30 dBm) |
| Ethernet | WIZnet W5500 (onboard W5500-EVB-Pico2 style) |
| Board | Raspberry Pi Pico 2 form factor |

## Related

- Firmware variant PR: meshtastic/firmware#10135
- Ethernet OTA PR: meshtastic/firmware#10136

🤖 Generated with [Claude Code](https://claude.ai/claude-code)