### PR TITLE
Remote Shell Protobufs

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -74,7 +74,7 @@
 *StoreForwardPlusPlus.root_hash max_size:32
 *StoreForwardPlusPlus.message max_size:240
 
-*DMShell.payload max_size:200
+*RemoteShell.payload max_size:200
 
 *StatusMessage.status max_size:80
 

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -74,6 +74,8 @@
 *StoreForwardPlusPlus.root_hash max_size:32
 *StoreForwardPlusPlus.message max_size:240
 
+*DMShell.payload max_size:200
+
 *StatusMessage.status max_size:80
 
 # MyMessage.name         max_size:40 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1289,9 +1289,9 @@ message StoreForwardPlusPlus {
 }
 
 /*
- * The actual over-the-mesh message doing DMShell
+ * The actual over-the-mesh message doing RemoteShell
  */
-message DMShell {
+message RemoteShell {
   /*
    * Frame op code for PTY session control and stream transport.
    *

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1317,10 +1317,6 @@ message DMShell {
     PONG = 68;
   }
 
-  /*
-   * Legacy bytes tunnel payload. New clients should prefer structured fields below.
-   */
-  // bytes ShellBytes = 1;
 
   /*
    * Structured frame operation.

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1317,7 +1317,6 @@ message RemoteShell {
     PONG = 68;
   }
 
-
   /*
    * Structured frame operation.
    */

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1289,6 +1289,81 @@ message StoreForwardPlusPlus {
 }
 
 /*
+ * The actual over-the-mesh message doing DMShell
+ */
+message DMShell {
+  /*
+   * Frame op code for PTY session control and stream transport.
+   *
+   * Values 1-63 are client->server requests.
+   * Values 64-127 are server->client responses/events.
+   */
+  enum OpCode {
+    OP_UNSET = 0;
+
+    // Client -> server
+    OPEN = 1;
+    INPUT = 2;
+    RESIZE = 3;
+    CLOSE = 4;
+    PING = 5;
+    ACK = 6;
+
+    // Server -> client
+    OPEN_OK = 64;
+    OUTPUT = 65;
+    CLOSED = 66;
+    ERROR = 67;
+    PONG = 68;
+  }
+
+  /*
+   * Legacy bytes tunnel payload. New clients should prefer structured fields below.
+   */
+  // bytes ShellBytes = 1;
+
+  /*
+   * Structured frame operation.
+   */
+  OpCode op = 1;
+
+  /*
+   * Logical PTY session identifier.
+   */
+  uint32 session_id = 2;
+
+  /*
+   * Monotonic sequence number for this frame.
+   */
+  uint32 seq = 3;
+
+  /*
+   * Cumulative ack sequence number.
+   */
+  uint32 ack_seq = 4;
+
+  /*
+   * Opaque bytes payload for INPUT/OUTPUT/ERROR and other frame bodies.
+   */
+  bytes payload = 5;
+
+  /*
+   * Terminal size columns used for OPEN/RESIZE signaling.
+   */
+  uint32 cols = 6;
+
+  /*
+   * Terminal size rows used for OPEN/RESIZE signaling.
+   */
+  uint32 rows = 7;
+
+  /*
+   * Bit flags for protocol extensions.
+   */
+  uint32 flags = 8;
+}
+
+/*
  * Waypoint message, used to share arbitrary locations across the mesh
  */
 message Waypoint {

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -116,6 +116,11 @@ enum PortNum {
   KEY_VERIFICATION_APP = 12;
 
   /*
+   * Module/port for handling key verification requests.
+   */
+  DM_SHELL_APP = 13;
+
+  /*
    * Provides a 'ping' service that replies to any packet it receives.
    * Also serves as a small example module.
    * ENCODING: ASCII Plaintext

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -116,7 +116,7 @@ enum PortNum {
   KEY_VERIFICATION_APP = 12;
 
   /*
-   * Module/port for handling key verification requests.
+   * Module/port for handling primitive remote shell access.
    */
   REMOTE_SHELL_APP = 13;
 

--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -118,7 +118,7 @@ enum PortNum {
   /*
    * Module/port for handling key verification requests.
    */
-  DM_SHELL_APP = 13;
+  REMOTE_SHELL_APP = 13;
 
   /*
    * Provides a 'ping' service that replies to any packet it receives.


### PR DESCRIPTION
This new proto provides an SSH-like experience over the mesh, using the PKI encryption flow. It's high packet rate to run an interactive session, so that element will be restricted to SHORT_FAST/SHORT_TURBO networks.