### PR TITLE
add NRF54L15_DK HardwareModel enum value (132)

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -889,6 +889,12 @@ enum HardwareModel {
   THINKNODE_M9 = 131;
 
   /*
+   * Nordic nRF54L15-DK (PCA10156) community port — Zephyr RTOS + external
+   * EBYTE E22-900M30S (SX1262) LoRa module. Firmware variant: nrf54l15dk.
+   */
+  NRF54L15_DK = 132;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reserves \`HardwareModel\` enum value **132** for the **Nordic nRF54L15-DK** community firmware port.

The port is tracked in [meshtastic/firmware#10193](https://github.com/meshtastic/firmware/pull/10193) and currently uses \`HardwareModel_PRIVATE_HW\` as a placeholder; once this PR merges and the regenerated protobufs propagate back into the firmware tree, \`HW_VENDOR\` can be flipped to the proper \`NRF54L15_DK\` value.

## Hardware

| | |
|---|---|
| Board | Nordic nRF54L15-DK (PCA10156) |
| SoC   | nRF54L15 (Arm Cortex-M33, BLE 5.4) |
| OS    | Zephyr RTOS — first Meshtastic port on Zephyr |
| Radio | External EBYTE E22-900M30S (SX1262, 30 dBm, 868/915 MHz) |
| Firmware variant | \`nrf54l15dk\` |

## Change

One new enum entry added to \`HardwareModel\` in \`meshtastic/mesh.proto\`, slotting between the last THINKNODE ID (131) and the reserved \`PRIVATE_HW\` (255). No other files touched.

## Test plan

- [x] \`meshtastic/mesh.proto\` parses cleanly (enum value is unique; no reshuffle of existing IDs).
- [ ] Downstream regeneration verified once maintainers run the buf pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)