### PR TITLE
add heltec-v4-r8 board

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -889,6 +889,11 @@ enum HardwareModel {
   THINKNODE_M9 = 131;
 
   /*
+   * The Heltec-V4-R8 uses an ESP32S3R8 chip, plus an SX1262.
+   */
+  HELTEC_V4_R8 = 132;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The RAM has been increased compared to the original v4 to facilitate the use of more functions such as maps. However, the pinout is significantly different from the original v4 and incompatible, so a new model has been submitted.