### PR TITLE
Add QMP6988 telemetry sensor type

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -881,6 +881,11 @@ enum TelemetrySensorType {
    * DS248X Bridge for one-wire temperature sensors
    */
   DS248X = 51;
+
+  /*
+   * QMP6988 high accuracy pressure and temperature sensor
+   */
+  QMP6988 = 52;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -891,6 +891,11 @@ enum TelemetrySensorType {
    * ICM-42607-P 6‑Axis IMU
    */
   ICM42607P = 53;
+
+  /*
+   * QMP6988 high accuracy pressure and temperature sensor
+   */
+  QMP6988 = 54;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Adds a new `QMP6988` value to `TelemetrySensorType`.

This is a small protobuf change needed for separate firmware support of the QMP6988 environmental sensor. The corresponding firmware PR uses this enum value to identify QMP6988 explicitly in telemetry.

> Related Issue: none

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
