### PR TITLE
ci: switch NPM publish to npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,6 +224,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [codegen, build-typescript]
     if: ${{ !inputs.dry_run }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download NPM package
         uses: actions/download-artifact@v4
@@ -236,10 +239,11 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install NPM CLI
+        run: npm install -g npm@latest
+
       - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish
 
   publish-jsr:
     runs-on: ubuntu-24.04

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -3,6 +3,10 @@
   "description": "Protobuf definitions for the Meshtastic project",
   "version": "__PACKAGE_VERSION__",
   "homepage": "https://github.com/meshtastic/protobufs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/meshtastic/protobufs.git"
+  },
   "license": "GPLV3",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Add id-token write permission, upgrade npm CLI, add repository field to package.json, and drop NODE_AUTH_TOKEN in favor of OIDC for NPM package publishing.
