### PR TITLE
feat: add PKI_DECRYPT_FAILED error

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1109,6 +1109,13 @@ message Routing {
      * This is different from PKI_UNKNOWN_PUBKEY which indicates a failure upon receiving a packet
      */
     PKI_SEND_FAIL_PUBLIC_KEY = 39;
+
+    /*
+     * PKI packet could not be decrypted, even though the sender's public key is in NodeDB.
+     * Typically happens after the sender rotated keys; may also happen due to RF corruption or
+     * builds without PKI support (MESHTASTIC_EXCLUDE_PKI).
+     */
+    PKI_DECRYPT_FAILED = 40;
   }
 
   oneof variant {


### PR DESCRIPTION
# What does this PR do?
Add a new error PKI_DECRYPT_FAILED so the sender can better understand why it received NAK.

> [Related Issue](https://github.com/meshtastic/firmware/discussions/6079)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
