### PR TITLE
feat(config): add dynamic coding rate settings

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1069,6 +1069,18 @@ message Config {
       NOT_PRESENT = 2;
     }
 
+    enum DynamicCodingRateMode {
+      /*
+       * Keep using the configured static coding rate.
+       */
+      DCR_OFF = 0;
+
+      /*
+       * Select LoRa coding rate per packet using local airtime policy.
+       */
+      DCR_ON = 1;
+    }
+
     /*
      * When enabled, the `modem_preset` fields will be adhered to, else the `bandwidth`/`spread_factor`/`coding_rate`
      * will be taked from their respective manually defined fields
@@ -1199,6 +1211,12 @@ message Config {
      * Don't use radiolib to initialize the radio, instead listen for a serialHal connection
      */
     bool serial_hal_only = 107;
+
+    /*
+     * Dynamic Coding Rate policy mode. DCR_OFF keeps the configured static coding rate; DCR_ON applies
+     * per-packet CR selection.
+     */
+    DynamicCodingRateMode dcr_mode = 108;
   }
 
   message BluetoothConfig {


### PR DESCRIPTION
Adds LoRaConfig fields for Dynamic Coding Rate (DCR): a binary `DCR_OFF` / `DCR_ON` mode, min/max CR clamps, a CR 4/8 airtime budget, local neighbor-tracking disable, and class-level CR bounds.

Companion firmware draft PR meshtastic/firmware#10327 consumes these generated fields for per-packet LoRa coding-rate policy.
