### PR TITLE
Fixing the confusing field description of the RangeTestConfig

### DIFF
--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -602,7 +602,8 @@ message ModuleConfig {
     bool enabled = 1;
 
     /*
-     * Send out range test messages from this node
+     * Sender interval. How long to wait between sending sequential test packets.
+     * 0 is default which disables sending messages.
      */
     uint32 sender = 2;
 


### PR DESCRIPTION
# What does this PR do?

Fixed `sender` field description. The description is taken from here: https://meshtastic.org/docs/configuration/module/range-test/#sender-interval

> No related issue.

## Checklist before merging

- [x] All top level messages commented
- ~~[ ] All enum members have unique descriptions~~