### PR TITLE
Add bounded client app metadata admin messages

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -19,3 +19,11 @@
 *HamParameters.call_sign max_size:8
 *HamParameters.short_name max_size:5
 *NodeRemoteHardwarePinsResponse.node_remote_hardware_pins max_count:16
+
+# Bounded client-app metadata store. app_id is ASCII [a-z0-9._-]{1,32}, so
+# 33 covers the 32-byte max plus the nanopb null terminator. Payload cap is
+# 512 bytes per the v1 RFC. TODO(maintainer): confirm sizes during review.
+*ClientAppData.app_id max_size:33
+*ClientAppData.payload max_size:512
+*AdminMessage.get_client_app_data_request max_size:33
+*AdminMessage.delete_client_app_data_request max_size:33

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -521,6 +521,39 @@ message AdminMessage {
      * Parameters and sensor configuration
      */
     SensorConfig sensor_config = 103;
+
+    /*
+     * Write a bounded local client-app metadata record. Local-only by
+     * default: the firmware refuses set_client_app_data from non-local
+     * senders. See top-level ClientAppData for the namespaced-not-owned
+     * caveat: any admin-capable client may overwrite any app_id, so
+     * callers must treat stored payloads as untrusted and recoverable.
+     * Validation failures (bad app_id, oversize payload, no slot free)
+     * are reported via meshtastic_Routing_Error_BAD_REQUEST.
+     * TODO(maintainer): confirm field-number allocation for 104..107.
+     */
+    ClientAppData set_client_app_data = 104;
+
+    /*
+     * Read a stored client-app metadata record by app_id. The firmware
+     * replies with get_client_app_data_response: a populated record on
+     * hit, or a record with empty app_id to signal NOT_FOUND.
+     */
+    string get_client_app_data_request = 105;
+
+    /*
+     * Stored client-app metadata in response to get_client_app_data_request.
+     * If app_id is empty, no record exists for the requested key.
+     */
+    ClientAppData get_client_app_data_response = 106;
+
+    /*
+     * Delete a stored client-app metadata record by app_id. Local-only by
+     * default. Returns Routing_Error_NONE on success (record removed) or
+     * Routing_Error_BAD_REQUEST on invalid app_id. Deleting a missing
+     * app_id is treated as success (idempotent).
+     */
+    string delete_client_app_data_request = 107;
   }
 }
 
@@ -759,4 +792,65 @@ message SHTXX_config {
    * Accuracy mode (0 = low, 1 = medium, 2 = high)
    */
   optional uint32 set_accuracy = 1;
+}
+
+/*
+ * Optional, bounded, local-node-only storage for opaque, app-owned metadata
+ * that a companion application can ask its locally-connected node to persist
+ * on its behalf. Not a filesystem, not a database, and not arbitrary NVRAM.
+ * It is a tiny fixed-slot table for a few small records.
+ *
+ * Intended to give clients an explicit, firmware-bounded place to store
+ * non-secret convenience metadata, without overloading user-visible
+ * fields like long_name or unrelated configuration surfaces.
+ *
+ * IMPORTANT: namespaced, not owned. The firmware enforces shape, payload
+ * size, and record-count limits, but does NOT authenticate which companion
+ * application is making a write request. app_id prevents accidental name
+ * collisions between apps, NOT malicious or intentional overwrites: any
+ * admin-capable client may overwrite or delete any app_id. Callers must
+ * therefore treat stored payloads as untrusted, optional, and recoverable.
+ *
+ * Do NOT store secrets, identity keys, session keys, paid-entitlement
+ * state, trust authority, blocklists, or any data used to make security,
+ * routing, authentication, or purchase decisions. Treat this as a
+ * convenience cache for non-critical app state only.
+ *
+ * Firmware never interprets `payload`, never broadcasts these records over
+ * LoRa, never includes them in NodeInfo, and never relays them via MQTT.
+ * Records are local-node-only, survive reboot, and are cleared by factory
+ * reset.
+ *
+ * Client guidance: gracefully fall back to app-local storage when the
+ * firmware does not support this feature; version your payloads via the
+ * `version` field below; keep payloads small (well under the 512-byte cap)
+ * to leave headroom for other apps.
+ */
+message ClientAppData {
+  /*
+   * Namespacing key. Must match `^[a-z0-9._-]{1,32}$`.
+   * Convention examples: "meshtastic-ios",
+   * "meshtastic-android", "thirdparty.example".
+   */
+  string app_id = 1;
+
+  /*
+   * Application-defined schema version for `payload`. The firmware does not
+   * interpret this; clients use it to migrate or reject stale payloads.
+   */
+  uint32 version = 2;
+
+  /*
+   * Opaque app-owned bytes, max 512. Firmware never inspects or interprets
+   * the contents.
+   */
+  bytes payload = 3;
+
+  /*
+   * Unix epoch seconds, set by the firmware on every successful write.
+   * May be 0 if the firmware does not yet have a valid wall-clock time.
+   * Useful for clients to detect that another admin-capable client has
+   * overwritten or deleted-then-recreated the record since the last read.
+   */
+  fixed32 updated_at = 4;
 }

--- a/meshtastic/localonly.options
+++ b/meshtastic/localonly.options
@@ -1,0 +1,8 @@
+# nanopb sizing for local-only persistence wrappers.
+# LocalConfig and LocalModuleConfig contain only nested message types whose
+# sizing is governed by their own .options files, so they have no entries
+# here.
+
+# Bounded client-app metadata store: max 4 records per node by default.
+# TODO(maintainer): confirm record cap during review.
+*LocalClientAppData.records max_count:4

--- a/meshtastic/localonly.proto
+++ b/meshtastic/localonly.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package meshtastic;
 
+import "meshtastic/admin.proto";
 import "meshtastic/config.proto";
 import "meshtastic/module_config.proto";
 
@@ -152,4 +153,26 @@ message LocalModuleConfig {
    * NodeDB.cpp in the device code.
    */
   uint32 version = 8;
+}
+
+/*
+ * On-disk wrapper for the bounded local client-app metadata store.
+ * Persisted by the firmware to /prefs/clientappdata.proto. Never sent over
+ * the wire and never broadcast. See ClientAppData (admin.proto) for the
+ * namespaced-not-owned caveat that governs how clients should treat the
+ * stored payloads.
+ */
+message LocalClientAppData {
+  /*
+   * The set of stored records. Bounded by localonly.options to a small
+   * number (initially 4). Firmware enforces uniqueness on app_id.
+   */
+  repeated ClientAppData records = 1;
+
+  /*
+   * A version integer used to invalidate old save files when we make
+   * incompatible changes. Set at build time by NodeDB.cpp in the device
+   * code, mirroring LocalConfig.version / LocalModuleConfig.version.
+   */
+  uint32 version = 2;
 }


### PR DESCRIPTION
## Summary

Add a small new wire surface so Meshtastic companion applications can ask their locally-connected node to persist a few opaque, app-defined metadata records on their behalf. The intent is to give companion apps an explicit place for non-secret convenience metadata, instead of overloading user-visible fields like `long_name` or unrelated configuration surfaces.

This is intentionally **namespaced, not owned**: the firmware enforces shape, payload size, and record-count limits, but it does NOT authenticate which client is writing. Any admin-capable client may overwrite or delete any `app_id`. Clients must therefore treat stored payloads as untrusted, optional, and recoverable.

Companion to the firmware implementation PR ([meshtastic/firmware#10392](https://github.com/meshtastic/firmware/pull/10392)) and the RFC ([Meshtastic/rfcs#12](https://github.com/meshtastic/rfcs/pull/12)).

## Wire / API shape

New top-level message in `meshtastic/admin.proto`:

```proto
message ClientAppData {
  string  app_id     = 1;   // ^[a-z0-9._-]{1,32}$
  uint32  version    = 2;   // app-defined schema version; firmware does not interpret
  bytes   payload    = 3;   // opaque to firmware, max 512 bytes
  fixed32 updated_at = 4;   // unix epoch seconds, firmware-set on write, 0 if no valid time
}
```

Four new `AdminMessage.payload_variant` fields:

```proto
ClientAppData set_client_app_data            = 104;
string        get_client_app_data_request    = 105;
ClientAppData get_client_app_data_response   = 106;
string        delete_client_app_data_request = 107;
```

New on-disk wrapper in `meshtastic/localonly.proto`:

```proto
message LocalClientAppData {
  repeated ClientAppData records = 1;   // capped at 4 by localonly.options
  uint32   version               = 2;
}
```

nanopb sizing in the `.options` files:

```
*ClientAppData.app_id max_size:33
*ClientAppData.payload max_size:512
*AdminMessage.get_client_app_data_request max_size:33
*AdminMessage.delete_client_app_data_request max_size:33
*LocalClientAppData.records max_count:4
```

## Limits

| | |
|---|---|
| `app_id` regex | `^[a-z0-9._-]{1,32}$` |
| `payload` max | 512 bytes |
| record max | 4 records per node |
| `updated_at` | firmware-set `fixed32` unix epoch seconds, 0 when RTC is invalid |

Worst-case on-disk footprint = `meshtastic_LocalClientAppData_size` = 2258 bytes.

## Namespaced, not owned

The firmware does not authenticate which companion app is making a write request. `app_id` prevents accidental name collisions between apps; it does NOT prove caller ownership. Any admin-capable client may be able to write or delete any `app_id`.

Clients **must** treat stored metadata as untrusted, optional, and recoverable. The companion app's own local/cloud/export storage remains the source of truth. **Do not store** secrets, identity keys, session keys, paid-entitlement state, trust authority, blocklists, or any data used to make security, routing, authentication, or purchase decisions.

Records are local-only by construction:

* never broadcast over LoRa
* never included in NodeInfo
* never relayed via MQTT
* firmware never interprets `payload`
* cleared by factory reset via the existing `/prefs` wipe path

## Compatibility

Wire-additive only. Existing clients that don't know about the new tags are unaffected. Older firmware that doesn't yet implement the feature returns `Routing_Error_NOT_AUTHORIZED` or no reply for the new tags; companion apps must treat that as "feature unavailable, fall back to app-local storage."

No version bump. No renumbering. No breaking changes to existing types.

## Validation

```
$ buf format --diff .
(no output, exit 0)

$ buf lint .
(no output, exit 0)

$ buf breaking . --against '.git#ref=origin/master'
(no output, exit 0)
```

All three buf checks pass clean against `master`. The firmware-side implementation regenerates nanopb output (committed in the firmware PR) and passes both `bash bin/test-native-docker.sh -f test_default` and `bash bin/test-native-docker.sh -f test_client_app_data` (27 store-level tests covering CRUD, slot accounting, payload bounds, persistence, factory-reset semantic, and storage-error injection).

## Linked

* RFC: [Meshtastic/rfcs#12](https://github.com/meshtastic/rfcs/pull/12)
* Firmware implementation PR: [meshtastic/firmware#10392](https://github.com/meshtastic/firmware/pull/10392)

## Maintainer questions

Specifically requesting confirmation on:

1. **Field-number allocation 104..107.** This sits in the next contiguous gap after `sensor_config = 103`. Happy to move if you have a different range in mind.
2. **Empty-`app_id` get-miss sentinel.** A read of an unknown key returns a `get_client_app_data_response` whose `app_id` is empty. This avoids introducing a one-off response-envelope pattern for this single feature, but it is a minor novelty. Acceptable, or do you want to wait for a broader admin-wide status model?
3. **512-byte / 4-record limits.** Worst-case 2.3 KB persistent footprint. Is this acceptable across constrained targets (STM32WL, low-flash nRF52 variants)? Should there be a `MESHTASTIC_EXCLUDE_CLIENT_APP_DATA` compile-out flag?

Other open questions are listed in the RFC.
