### PR TITLE
Add MeshPacket.tx_power_penalty_db (whisper)

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -43,6 +43,7 @@
 *MeshPacket.channel int_size:8
 *MeshPacket.next_hop int_size:8
 *MeshPacket.relay_node int_size:8
+*MeshPacket.tx_power_penalty_db int_size:8
 
 *QueueStatus.res int_size:8
 *QueueStatus.free int_size:8

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1769,6 +1769,27 @@ message MeshPacket {
    * Indicates which transport mechanism this packet arrived over
    */
   TransportMechanism transport_mechanism = 21;
+
+  /*
+   * dB to subtract from the configured tx_power for this single packet.
+   * Used to "whisper" a message to nearby nodes without raising the
+   * noise floor for the wider mesh: lower power keeps the packet local
+   * but still reaches physically close neighbors.
+   *
+   * Only the originating device applies the penalty. Relays and
+   * rebroadcasts use their own configured tx_power, so the whisper
+   * does not propagate. The originator's want_ack retries reuse the
+   * same MeshPacket and inherit the penalty.
+   *
+   * *Never* sent over the radio links. Clamped on the originating
+   * firmware to the radio's hardware minimum on the low end and to
+   * 60 dB on the high end.
+   *
+   * Note: the generated C struct is uint8_t (see mesh.options
+   * `int_size:8`), so values above 255 are silently truncated on
+   * decode. The 60 dB upper clamp catches whatever survives.
+   */
+  uint32 tx_power_penalty_db = 22;
 }
 
 /*


### PR DESCRIPTION
Adds tx_power_penalty_db to MeshPacket. Per-packet dB penalty subtracted from the configured tx_power, applied only by the originating device. Lets a sender whisper a message to nearby nodes without adding to mesh-wide congestion. Local-only, never on the wire.

Generated C struct shrinks to uint8_t via mesh.options int_size:8 (same pattern as LoRaConfig.tx_power). Firmware implementation will follow in a separate PR once this is reviewed.