### PR TITLE
Add EXAMPLE_APP portnum

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -121,6 +121,14 @@ enum PortNum {
   REMOTE_SHELL_APP = 13;
 
   /*
+   * Example / developer reference module.
+   * A minimal, heavily-commented module included in the firmware for educational
+   * purposes and as a starting point for custom module development.
+   * ENCODING: ASCII Plaintext
+   */
+  EXAMPLE_APP = 14;
+
+  /*
    * Provides a 'ping' service that replies to any packet it receives.
    * Also serves as a small example module.
    * ENCODING: ASCII Plaintext


### PR DESCRIPTION
## Summary

Adds `EXAMPLE_APP = 14` to `PortNum` for a future developer reference module in the firmware.

This is part of the work discussed in meshtastic/firmware Discussion #10422:
https://github.com/meshtastic/firmware/discussions/10422

## Rationale

The firmware currently has `ReplyModule`, but it is very minimal and only demonstrates `allocReply()`. A dedicated example module would make it easier for new contributors to understand the module lifecycle without reading several unrelated modules.

The new `EXAMPLE_APP` portnum is intended for that didactic module.

## Notes

- Uses value `14`, currently free in the core Meshtastic range (`0-63`).
- The follow-up firmware PR will update the protobufs submodule, regenerate generated protobuf files, and add the actual `ExampleModule`.