### PR TITLE
feat(mesh): add BLE advertisement protobuf enums

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -591,6 +591,11 @@ message Config {
        * Enable broadcasting packets via UDP over the local network
        */
       UDP_BROADCAST = 0x0001;
+
+      /*
+       * Enable broadcasting packets over Bluetooth LE advertisements
+       */
+      BLE_ADVERTISEMENT_BROADCAST = 0x0002;
     }
   }
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -900,7 +900,6 @@ enum HardwareModel {
 
   /*
    * B&Q Consulting Station G3: TBD
-
    */
   STATION_G3 = 134;
   /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1621,6 +1621,11 @@ message MeshPacket {
      * Arrived via API connection
      */
     TRANSPORT_API = 7;
+
+    /*
+     * Arrived via Bluetooth LE advertisements
+     */
+    TRANSPORT_BLE_ADVERTISEMENT = 8;
   }
 
   /*


### PR DESCRIPTION
## What does this PR do?

Adds protobuf enum values needed by the firmware BLE advertisement bearer scaffold:

- `Config.NetworkConfig.ProtocolFlags.BLE_ADVERTISEMENT_BROADCAST` for enabling BLE advertisement packet broadcasts.
- `MeshPacket.TransportMechanism.TRANSPORT_BLE_ADVERTISEMENT` so packets received through that bearer can be tagged distinctly.
- Removes one pre-existing blank line that `buf format` rejects in `meshtastic/mesh.proto`, so this PR can pass the current format gate after touching that file.

This supports meshtastic/firmware#10292; that firmware draft should stay draft until this schema lands and generated bindings are refreshed from the canonical protobufs submodule.

> [Related Issue](https://github.com/meshtastic/firmware/pull/10292)

## Validation

- `buf format --diff --exit-code --path meshtastic/config.proto --path meshtastic/mesh.proto .`
- `buf lint --path meshtastic/config.proto --path meshtastic/mesh.proto .`
- `buf lint .`
- `protoc -I. --include_imports --descriptor_set_out=/tmp/meshtastic-ble-adv.desc meshtastic/*.proto nanopb.proto`
- `git diff --check origin/master...HEAD`
- `codex review --base origin/master`

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions