### PR TITLE
Add ITU Region 1 and Region 2/3 Amateur Radio 70cm regions

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -960,6 +960,17 @@ message Config {
        * EU 868MHz band, with narrow presets
        */
       EU_N_868 = 32;
+
+      /*
+       * ITU Region 1 Amateur Radio 70cm band (430-440 MHz)
+       */
+      ITU1_70CM = 33;
+
+      /*
+       * ITU Region 2 / 3 Amateur Radio 70cm band (430-450 MHz)
+       * Note: Some countries do not allocate 440-450 MHz. Check local law!
+       */
+      ITU23_70CM = 34;
     }
 
     /*


### PR DESCRIPTION
This pull request adds support for additional frequency bands in the configuration options, specifically targeting the amateur radio 70cm bands for ITU regions. This expands the flexibility for users operating in different regions.

New frequency band options:

* Added `ITU1_70CM` for the ITU Region 1 Amateur Radio 70cm band (430–440 MHz) to the `Config` message enum in `meshtastic/config.proto`.
* Added `ITU23_70CM` for the ITU Region 2/3 Amateur Radio 70cm band (430–450 MHz), with a note about local legal restrictions, to the `Config` message enum in `meshtastic/config.proto`.