### PR TITLE
develop: Update 70cm ham regions, split by ITU

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -972,10 +972,17 @@ message Config {
       ITU1_70CM = 34;
 
       /*
-       * ITU Region 2 / 3 Amateur Radio 70cm band (430-450 MHz)
+       * ITU Region 2 Amateur Radio 70cm band (420-450 MHz)
+       * Note: Some countries do not allocate 420-430 MHz or 440-450 MHz.
+       * Check local law!
+       */
+      ITU2_70CM = 35;
+
+      /*
+       * ITU Region 3 Amateur Radio 70cm band (430-450 MHz)
        * Note: Some countries do not allocate 440-450 MHz. Check local law!
        */
-      ITU23_70CM = 35;
+      ITU3_70CM = 36;
     }
 
     /*


### PR DESCRIPTION
**NOTE**: This PR includes renames! (Normally breaking, but nothing relies upon these protos yet)

Stop combining ITU 2 and 3. They will need VERY different default slotOverrides (default freq).

In effect, this means each ham band we support will need 3 "regions", ITU1, ITU2, ITU3.

This will allow us to better support hams around the world (hopefully) without stirring anger.

Depends on:
- #923 (master)
- #925 (develop)