### PR TITLE
Update snapshot repository settings in kmp README

### DIFF
--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -51,7 +51,7 @@ repository alongside `mavenCentral()` and depend on a `-SNAPSHOT` version:
 repositories {
   mavenCentral()
   maven("https://central.sonatype.com/repository/maven-snapshots/") {
-      content { includeGroup("org.meshtastic") }
+        mavenContent { snapshotsOnly() }
   }
 }
 

--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -49,8 +49,10 @@ repository alongside `mavenCentral()` and depend on a `-SNAPSHOT` version:
 ```kotlin
 // settings.gradle.kts (or build.gradle.kts)
 repositories {
-    mavenCentral()
-    maven("https://central.sonatype.com/repository/maven-snapshots/")
+  mavenCentral()
+  maven("https://central.sonatype.com/repository/maven-snapshots/") {
+      content { includeGroup("org.meshtastic") }
+  }
 }
 
 // build.gradle.kts


### PR DESCRIPTION
Updated Maven repository settings instructions to restrict (include) specific group to avoid consumers churning on lookups.
