### PR TITLE
kmp: replace proto symlinks with direct sourcePath refs

### DIFF
--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -62,9 +62,21 @@ tasks.withType<Jar>().configureEach {
     from(rootProject.layout.projectDirectory.file("../../LICENSE"))
 }
 
+val repoRoot = rootProject.layout.projectDirectory.dir("../../")
+
+val syncProtos by tasks.registering(Sync::class) {
+    from(repoRoot.dir("meshtastic"))
+    into(layout.buildDirectory.dir("protos/meshtastic"))
+}
+
+val syncNanopb by tasks.registering(Sync::class) {
+    from(repoRoot.file("nanopb.proto"))
+    into(layout.buildDirectory.dir("protos"))
+}
+
 wire {
     sourcePath {
-        srcDir("proto")
+        srcDir(layout.buildDirectory.dir("protos"))
         include("meshtastic/**/*.proto")
         include("nanopb.proto")
     }
@@ -81,6 +93,13 @@ wire {
         // Skip defensive immutable copies of repeated/map fields on decode.
         // Reduces allocations on high-frequency decode paths (mesh packets).
         makeImmutableCopies = false
+    }
+}
+
+// Ensure protos are synced before Wire generates code
+afterEvaluate {
+    tasks.matching { it.name.startsWith("generate") && it.name.endsWith("Protos") }.configureEach {
+        dependsOn(syncProtos, syncNanopb)
     }
 }
 

--- a/packages/kmp/proto/meshtastic
+++ b/packages/kmp/proto/meshtastic
@@ -1,1 +1,0 @@
-../../../meshtastic

--- a/packages/kmp/proto/nanopb.proto
+++ b/packages/kmp/proto/nanopb.proto
@@ -1,1 +1,0 @@
-../../../nanopb.proto


### PR DESCRIPTION
Remove the symlinked `proto/` directory and instead sync proto files from the repository root into `build/protos/` before Wire codegen. This prevents downstream consumers from rediscovering/re-generating the raw `.proto` files when they depend on the published KMP artifact, while keeping Gradle's task dependency graph valid under Gradle 9's strict validation.

**What changed:**
- Deleted `packages/kmp/proto/meshtastic` symlink → `../../../meshtastic`
- Deleted `packages/kmp/proto/nanopb.proto` symlink → `../../../nanopb.proto`
- Added `Sync` tasks that copy protos from repo root into `build/protos/`
- Pointed Wire's `sourcePath` at `build/protos/` instead of the symlinked `proto/` dir

Fixes: https://github.com/meshtastic/Meshtastic-Android/actions/runs/26690456880/job/78665851074?pr=5676