### PR TITLE
feat(kmp): add JS, Wasm, and additional native publish targets

### DIFF
--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -5,7 +5,7 @@ This package publishes Kotlin Multiplatform models generated from the protobuf s
 ## What this provides
 
 - A single generated-model source of truth for downstream Kotlin and KMP clients.
-- Kotlin/Android, Kotlin/JVM, and Kotlin/Native (iOS) artifacts from the same protobuf schema.
+- Kotlin/Android, Kotlin/JVM, Kotlin/JS, Kotlin/Wasm (`wasmJs` and `wasmWasi`), and Kotlin/Native artifacts from the same protobuf schema.
 - Wire runtime-based models in the existing protobuf namespace (`meshtastic` package from `.proto`).
 - Wire reads schema sources from `packages/kmp/proto/`, which symlinks back to the repo-root proto files.
 
@@ -35,9 +35,18 @@ implementation("org.meshtastic:protobufs:2.7.23")
 // Platform-specific artifacts (resolved automatically by Gradle KMP):
 //   org.meshtastic:protobufs-android
 //   org.meshtastic:protobufs-jvm
+//   org.meshtastic:protobufs-js
+//   org.meshtastic:protobufs-wasm-js
+//   org.meshtastic:protobufs-wasm-wasi
 //   org.meshtastic:protobufs-iosx64
 //   org.meshtastic:protobufs-iosarm64
 //   org.meshtastic:protobufs-iossimulatorarm64
+//   org.meshtastic:protobufs-tvosarm64
+//   org.meshtastic:protobufs-tvossimulatorarm64
+//   org.meshtastic:protobufs-macosarm64
+//   org.meshtastic:protobufs-linuxx64
+//   org.meshtastic:protobufs-linuxarm64
+//   org.meshtastic:protobufs-mingwx64
 ```
 
 ### Snapshots

--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -33,6 +33,7 @@ repositories {
     mavenCentral()
 }
 
+@OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
 kotlin {
     android {
         namespace = "org.meshtastic.proto"
@@ -40,9 +41,25 @@ kotlin {
         minSdk = 24
     }
     jvm()
+    js {
+        browser()
+        nodejs()
+    }
+    wasmJs {
+        browser()
+    }
+    wasmWasi {
+        nodejs()
+    }
+    macosArm64()
+    linuxX64()
+    linuxArm64()
+    mingwX64()
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    tvosArm64()
+    tvosSimulatorArm64()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
# What does this PR do?

The KMP module was only publishing Android, JVM, and iOS artifacts. This expands coverage to every platform where `wire-runtime:6.4.0` provides variant support, so downstream consumers on JS, Wasm, desktop, and server can depend on the same generated protobuf models.

New targets added:

- **Kotlin/JS** (browser + Node.js)
- **Kotlin/WasmJs** (browser)
- **Kotlin/WasmWasi** (Node.js)
- **macosArm64** (Apple Silicon desktop/server)
- **linuxX64**, **linuxArm64** (Linux server/embedded)
- **mingwX64** (Windows)
- **tvosArm64**, **tvosSimulatorArm64** (Apple TV)

watchOS targets are intentionally omitted -- `wire-runtime` does not publish watchOS native variants yet.

No CI workflow changes are needed; existing workflows already run on `macos-latest` and use `publishAllPublications`, which automatically picks up the new targets.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

### New Hardware Model Acceptance Policy

N/A