### PR TITLE
Add ITU Region 2 Amateur Radio 1.25m band

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -983,6 +983,13 @@ message Config {
        * Note: Some countries do not allocate 440-450 MHz. Check local law!
        */
       ITU3_70CM = 36;
+
+      /*
+       * ITU Region 2 Amateur Radio 1.25m '125cm' band (220-225 MHz)
+       * Note: Some countries do not allocate 220-222 MHz (Ex: USA/Canada).
+       * Check local law!
+       */
+      ITU2_125CM = 37;
     }
 
     /*


### PR DESCRIPTION
This pull request adds support for the ITU Region 2 1.25m (220-225 MHz) amateur radio band to the configuration options. 
This is a band that is only available in ITU Region 2 (the Americas) (no allocations in ITU1 or ITU3).

New frequency band support:

* Added `ITU2_125CM` (1.25m, 220-225 MHz) option to the `BandId` enum in `meshtastic/config.proto`, with appropriate documentation and legal notes.