### PR TITLE
Add TINY_FAST and TINY_SLOW presets for Amateur Radio compliance

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1073,6 +1073,26 @@ message Config {
        * Comparable link budget and data rate to LONG_FAST.
        */
       NARROW_SLOW = 13;
+
+      /*
+       * Tiny Fast
+       * Preset optimized for compliance with Amateur Radio restrictions with 20kHz bandwidth.
+       * Many regions limit data transmission bandwidth in lower amateur bands (2 Meter).
+       * Note: TCXO with tight tolerances (±5 ppm or better) is *absolutely required* at these narrow bandwidths.
+       * Only compatible with SX127x and SX126x chipsets.
+       * Comparable link budget and data rate to LONG_FAST.
+       */
+      TINY_FAST = 14;
+
+      /*
+       * Tiny Slow
+       * Preset optimized for compliance with Amateur Radio restrictions with 20kHz bandwidth.
+       * Many regions limit data transmission bandwidth in lower amateur bands (2 Meter).
+       * Note: TCXO with tight tolerances (±5 ppm or better) is *absolutely required* at these narrow bandwidths.
+       * Only compatible with SX127x and SX126x chipsets.
+       * Comparable link budget and data rate to LONG_MODERATE.
+       */
+      TINY_SLOW = 15;
     }
 
     enum FEM_LNA_Mode {


### PR DESCRIPTION
Add two new presets:
- `TINY_FAST`
- `TINY_SLOW`

These will be used to enable ultra-narrow presets (20khz) on Amateur Radio devices.
This is necessary for regulatory compliance in the 2M and 70CM bands.

firmware PR:
- https://github.com/meshtastic/firmware/pull/10597

I have tested these narrow bandwidths on T-Beam BPF and it's still working with 200 char messages (got a nice TCXO)!