### PR TITLE
fix battery_level

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -29,24 +29,24 @@ enum BatteryStatus {
   CHARGING = 2;
 
   /*
-   *Externally powered and fully charged
+   * Externally powered and fully charged
    */
   FULLY_CHARGED = 3;
 
   /*
-   *Battery not present
+   * Battery not present
    */
   NOT_PRESENT = 4;
 
   /*
-   * Externally powered but not charging (charging disabled, not supported)
+   * Externally powered but not charging (disabled, suspended, or not supported)
    */
   NOT_CHARGING = 5;
 
   /*
    * Externally powered but not charging due to anomaly (fault detected)
    */
-  CHARGE_FAILURE = 6;
+  NOT_PRESENT = 6;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -8,12 +8,38 @@ option java_outer_classname = "TelemetryProtos";
 option java_package = "org.meshtastic.proto";
 option swift_prefix = "";
 
+/**
+ * Details about charging state of the battery.
+ * Added to preserve the battery percentage while it's charging.
+ */
+enum BatteryStatus {
+  /*
+   * No further information (yet)
+   */
+  UNKNOWN = 0;
+
+  /*
+   * Running on battery (not externally powered)
+   */
+  DISCHARGING = 1;
+
+  /*
+   * Externally powered and actively charging
+   */
+  CHARGING = 2;
+
+  /*
+   * Externally powered but not charging (already full, waiting, or out of temperature range)
+   */
+  NOT_CHARGING = 3;
+}
+
 /*
  * Key native device metrics such as battery level
  */
 message DeviceMetrics {
   /*
-   * 0-100 (>100 means powered)
+   * 0-100
    */
   optional uint32 battery_level = 1;
 
@@ -36,6 +62,11 @@ message DeviceMetrics {
    * How long the device has been running since the last reboot (in seconds)
    */
   optional uint32 uptime_seconds = 5;
+
+  /*
+   * Details about powered and charging state
+   */
+  optional BatteryStatus battery_status = 6;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -46,7 +46,7 @@ enum BatteryStatus {
   /*
    * Externally powered but not charging due to anomaly (fault detected)
    */
-  NOT_PRESENT = 6;
+  CHARGE_FAILURE = 6;
 }
 
 /*

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -16,7 +16,7 @@ enum BatteryStatus {
   /*
    * No further information (yet)
    */
-  UNKNOWN = 0;
+  BATTERY_STATUS_UNKNOWN = 0;
 
   /*
    * Running on battery (not externally powered)

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -29,9 +29,24 @@ enum BatteryStatus {
   CHARGING = 2;
 
   /*
-   * Externally powered but not charging (already full, waiting, or out of temperature range)
+   *Externally powered and fully charged
    */
-  NOT_CHARGING = 3;
+  FULLY_CHARGED = 3;
+
+  /*
+   *Battery not present
+   */
+  NOT_PRESENT = 4;
+
+  /*
+   * Externally powered but not charging (charging disabled, not supported)
+   */
+  NOT_CHARGING = 5;
+
+  /*
+   * Externally powered but not charging due to anomaly (fault detected)
+   */
+  CHARGE_FAILURE = 6;
 }
 
 /*


### PR DESCRIPTION
This PR fixes the `battery_level` field which has been hijacked by a powered state (`battery_level` > 100).

While powered to USB / charging the battery the UI has no percentage information about the battery level except when re-implementing the battery curves (i.e. deduct from actual voltage) which are already implemented in the firmware. For a user this is a poor experience as he doesn't see the actual percentage level of his device to know when it's fully charged, but many devices already provide this detail of information.

This PR removes this semantic from `battery_level` by defining a clean new `battery_status` field that provides distinct charging information and helps to preserve the percentage information during charging. 

<img width="1280" height="584" alt="image" src="https://github.com/user-attachments/assets/ec87e772-d109-47fb-be01-de22b787e3dd" />

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
