### PR TITLE
Add "Long_Name" to HamParameters

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -18,6 +18,7 @@
 
 *HamParameters.call_sign max_size:8
 *HamParameters.short_name max_size:5
+*HamParameters.long_name max_size:15
 *NodeRemoteHardwarePinsResponse.node_remote_hardware_pins max_count:16
 
 *LockdownAuth.passphrase max_size:32

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -691,6 +691,12 @@ message HamParameters {
    * Optional short name of user
    */
   string short_name = 4;
+
+  /*
+   * Optional long name of user
+   * Appended to callsign
+   */
+  string long_name = 5;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Adds Long_Name HamParameters.

This will be appended to the call_sign in firmware with a // delimter (following Amateur Radio best practices). Since the max length for a callsign is 8 and // uses two characters. The limit for HamParameter.long_name is set to **15** (10 less than traditional LongName).

E.g.
call_sign = `N0CALL`
long_name = `Attic Heltec v3`
becomes
`N0CALL//Attic Heltec v3`

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
