### PR TITLE
ci: hold Kotlin at 2.3.x until Meshtastic-Android can consume 2.4-built klibs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold Kotlin at 2.3.x: the KMP artifact (org.meshtastic:protobufs) publishes native klibs, and klibs built by Kotlin 2.4 carry ABI version 2.4.0, which consumers on Kotlin 2.3.x (Meshtastic-Android, until InsertKoinIO/koin#2431 resolves) reject at compile time. Drop this rule once Meshtastic-Android is on Kotlin 2.4.",
+      "matchPackageNames": ["/^org\\.jetbrains\\.kotlin[.:]/"],
+      "allowedVersions": "<2.4.0"
+    }
   ]
 }


### PR DESCRIPTION
## Why

The KMP artifact (`org.meshtastic:protobufs`, added in #924) publishes native klibs. Klibs built by Kotlin 2.4 carry **ABI version 2.4.0**, which Kotlin 2.3.x consumers hard-reject:

```
The current Kotlin compiler can consume libraries having ABI version <= '2.3.0'.
Please upgrade your Kotlin compiler version to consume this library.
```

Meshtastic-Android is pinned to Kotlin **2.3.21** until the Koin compiler plugin supports 2.4 (InsertKoinIO/koin#2431), and meshtastic/Meshtastic-Android#5675 makes it consume this artifact directly. Without this guard, a routine Renovate Kotlin bump here would make the next `org.meshtastic:protobufs` release silently unconsumable for the app.

This already bit us with the other two KMP libs: MQTTastic-Client-KMP 0.3.7 and TAKPacket-SDK 0.5.3 were built on Kotlin 2.4.0, which is why meshtastic/Meshtastic-Android#5763 fails CI. MQTTastic is getting the same Renovate guard.

## What

A single Renovate `packageRules` entry holding `org.jetbrains.kotlin*` (plugin ids and maven coords; `kotlinx` is unaffected) below 2.4.0.

**Drop this rule once Meshtastic-Android lands its Kotlin 2.4 upgrade** (meshtastic/Meshtastic-Android#5760).

🤖 Generated with [Claude Code](https://claude.com/claude-code)