### PR TITLE
Publish KMP snapshots from develop with branch-named versions

### DIFF
--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - develop
     paths:
       - "meshtastic/**/*.proto"
       - "nanopb.proto"
@@ -18,17 +19,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Compute snapshot version
-        id: version
-        run: |
-          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          RELEASE_VERSION="${TAG#v}"
-          IFS='.' read -r major minor patch <<< "$RELEASE_VERSION"
-          SNAPSHOT_VERSION="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          echo "snapshot=$SNAPSHOT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -43,7 +33,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build KMP package
-        run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ steps.version.outputs.snapshot }}
+        run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ github.ref_name }}-SNAPSHOT
 
       - name: Publish snapshot to Maven Central
         env:
@@ -56,4 +46,4 @@ jobs:
             echo "Missing Maven Central secrets — skipping snapshot publish." >&2
             exit 0
           fi
-          packages/kmp/gradlew --no-daemon -p packages/kmp publishAllPublicationsToMavenCentralRepository -PVERSION_NAME=${{ steps.version.outputs.snapshot }}
+          packages/kmp/gradlew --no-daemon -p packages/kmp publishAllPublicationsToMavenCentralRepository -PVERSION_NAME=${{ github.ref_name }}-SNAPSHOT

--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -18,7 +18,8 @@ The SDK version is derived automatically from the latest git tag — no manual v
 | Context | Version | Source |
 |---------|---------|--------|
 | Release CI (`v2.7.23` tag push) | `2.7.23` | Tag stripped of `v` prefix, passed as `-PVERSION_NAME` |
-| Snapshot CI (master push) | `2.7.24-SNAPSHOT` | Latest tag + patch bump, computed in workflow |
+| Snapshot CI (`master` push) | `master-SNAPSHOT` | Branch name, passed as `-PVERSION_NAME` |
+| Snapshot CI (`develop` push) | `develop-SNAPSHOT` | Branch name, passed as `-PVERSION_NAME` |
 | Local dev (no flag) | `2.7.24-SNAPSHOT` | `git describe --tags --abbrev=0` + patch bump |
 | Local override | any | `./gradlew build -PVERSION_NAME=x.y.z` |
 
@@ -51,9 +52,11 @@ implementation("org.meshtastic:protobufs:2.7.23")
 
 ### Snapshots
 
-Snapshot builds (published from `master`) live in the Central Portal snapshots
-repository, not on the main Maven Central CDN. To consume them, add that
-repository alongside `mavenCentral()` and depend on a `-SNAPSHOT` version:
+Snapshot builds are published from `master` and `develop` under the stable
+coordinates `master-SNAPSHOT` and `develop-SNAPSHOT` — pin once and every push
+to that branch republishes the same version. They live in the Central Portal
+snapshots repository, not on the main Maven Central CDN. To consume them, add
+that repository alongside `mavenCentral()`:
 
 ```kotlin
 // settings.gradle.kts (or build.gradle.kts)
@@ -65,7 +68,16 @@ repositories {
 }
 
 // build.gradle.kts
-implementation("org.meshtastic:protobufs:2.7.24-SNAPSHOT")
+implementation("org.meshtastic:protobufs:develop-SNAPSHOT")
+```
+
+Gradle caches snapshot resolutions for 24 hours by default. To always pick up
+the latest publish during active development:
+
+```kotlin
+configurations.all {
+  resolutionStrategy.cacheChangingModulesFor(0, "minutes")
+}
 ```
 
 ## Local build


### PR DESCRIPTION
# What does this PR do?

Adds `develop` as a snapshot-publishing branch for the KMP package and switches snapshot versions from tag-derived (`2.7.24-SNAPSHOT`) to branch-named (`master-SNAPSHOT`, `develop-SNAPSHOT`).

## Why

- **`develop` becomes consumable for dev work** — downstream apps can depend on `org.meshtastic:protobufs:develop-SNAPSHOT` from the Central Portal snapshots repository.
- **Stable coordinates** — with the tag-derived scheme, every release tag shifted the snapshot version and silently broke consumer pins. Branch-named snapshots are pinned once; every push republishes the same coordinate.
- **No release ambiguity** — `2.7.24-SNAPSHOT` implies what `2.7.24` will be, which stops being true the moment the real release ships from a different commit.

## Changes

- `.github/workflows/snapshot-kmp.yml`: trigger on pushes to `develop` as well as `master` (same proto/KMP path filters); publish as `${{ github.ref_name }}-SNAPSHOT`. The `git describe` version-compute step and `fetch-depth: 0` checkout are removed since the version no longer depends on tags.
- `packages/kmp/README.md`: updated versioning table and snapshot consumption docs, including a note on Gradle's 24-hour snapshot cache.

## Notes for reviewers

- Consumers currently pinned to a numbered snapshot (e.g. `2.7.24-SNAPSHOT`) won't receive new builds at that coordinate after this merges — they should switch to `master-SNAPSHOT` or `develop-SNAPSHOT`.
- Release publishing (`publish-kmp.yml`) and the local-dev version fallback (tag + patch bump computed in the Gradle build) are unchanged.
- Checklist (proto message/enum comments) is N/A — no `.proto` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)