### PR TITLE
Move SNR in nodeDB to a Sint based figure, saving 2 bytes

### DIFF
--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -119,8 +119,8 @@ message NodeInfoLite {
   reserved "user", "position";
 
   /*
-   * Returns the Signal-to-noise ratio (SNR) of the last received message,
-   * as measured by the receiver. Return SNR of the last received message in dB
+   * In-memory SNR of the last received message in dB. Not serialised directly:
+   * always zeroed before encode; persisted as snr_q4 = 19 below.
    */
   float snr = 4;
 
@@ -184,6 +184,13 @@ message NodeInfoLite {
    * The public key of the user's device, for PKI-based encrypted DMs.
    */
   bytes public_key = 18;
+
+  /*
+   * Q4-encoded SNR: dB × 4, sint32 zigzag. Matches RouteDiscovery convention.
+   * Encode: snr_q4 = (int32_t)(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
+   * float snr is always zeroed on disk; this field carries all persisted SNR.
+   */
+  sint32 snr_q4 = 19;
 }
 
 /*


### PR DESCRIPTION
Needed for https://github.com/meshtastic/firmware/pull/10705