### PR TITLE
Add LoRa region preset mapping to support region-specific modem presets

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -96,6 +96,19 @@
 
 *DeviceMetadata.firmware_version max_size:18
 
+# Region->preset compatibility map (FromRadio.region_presets). Bounds chosen
+# above the current table (6 groups / 9 presets in the largest group / 32 regions)
+# so LoRaRegionPresetMap stays small enough that FromRadio_size does not grow past
+# the 512-byte MAX_TO_FROM_RADIO_SIZE cap. nanopb sizes repeated enums unpacked
+# (~2 bytes/element), so the flat groups + region_groups layout keeps cost additive
+# rather than groups*regions. See bin/regen-protos.sh output for the actual size.
+# region_groups capped at 38 = the number of RegionCode enum values, so it can
+# never overflow regardless of how many regions gain a firmware table entry.
+*LoRaRegionPresetMap.groups        max_count:8
+*LoRaRegionPresetMap.region_groups max_count:38
+*LoRaPresetGroup.presets           max_count:11
+*LoRaRegionPresets.group_index     int_size:8
+
 *MqttClientProxyMessage.topic max_size:60
 *MqttClientProxyMessage.data max_size:435
 *MqttClientProxyMessage.text max_size:435

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2337,6 +2337,15 @@ message FromRadio {
      * encoding state as magic-string prefixes inside ClientNotification.
      */
     LockdownStatus lockdown_status = 18;
+
+    /*
+     * Map of which modem presets are legal in each LoRa region. Sent once
+     * during the want_config handshake (right after `metadata`, before the
+     * first `channel`) so client UIs can prevent the user from selecting an
+     * illegal region+preset combination. A region that does not appear in
+     * any group carries no constraint info and should not be restricted.
+     */
+    LoRaRegionPresetMap region_presets = 19;
   }
 }
 
@@ -2675,6 +2684,74 @@ message DeviceMetadata {
    * (bitwise OR of ExcludedModules)
    */
   uint32 excluded_modules = 12;
+}
+
+/*
+ * A distinct set of legal modem presets shared by one or more LoRa regions.
+ * Regions that have an identical preset list / default / licensing reference
+ * the same group (by index) via LoRaRegionPresetMap.region_groups. This keeps
+ * the whole map small enough to fit in a single FromRadio packet, since most
+ * regions share the one standard preset list.
+ */
+message LoRaPresetGroup {
+  /*
+   * The modem presets that are legal for every region referencing this group.
+   */
+  repeated Config.LoRaConfig.ModemPreset presets = 1;
+
+  /*
+   * The firmware's default modem preset for regions in this group.
+   * Always one of `presets`. Clients should select this when switching to one
+   * of these regions, or when the current preset is not legal in the new region.
+   */
+  Config.LoRaConfig.ModemPreset default_preset = 2;
+
+  /*
+   * True if regions referencing this group are for licensed operators only
+   * (e.g. amateur / ham radio bands). Clients should warn or gate accordingly.
+   */
+  bool licensed_only = 3;
+}
+
+/*
+ * Associates a single LoRa region with its preset group.
+ */
+message LoRaRegionPresets {
+  /*
+   * The LoRa region this entry describes.
+   */
+  Config.LoRaConfig.RegionCode region = 1;
+
+  /*
+   * Index into LoRaRegionPresetMap.groups for the preset list that is legal
+   * in `region`.
+   */
+  uint32 group_index = 2;
+}
+
+/*
+ * Map describing which modem presets are valid for each LoRa region. Sent by
+ * the firmware during the want_config handshake (as FromRadio.region_presets)
+ * so that client UIs can prevent illegal region+preset selections.
+ *
+ * Delivery is grouped to save space: `groups` holds each distinct preset list,
+ * and `region_groups` maps every known region to one of those groups by index.
+ * A region that does NOT appear in `region_groups` carries no constraint
+ * information and should not be restricted by the client (e.g. firmware that
+ * predates this message, or a region with no firmware table entry). Clients
+ * must also tolerate this whole message being absent.
+ */
+message LoRaRegionPresetMap {
+  /*
+   * One entry per distinct (preset-list, default, licensing) combination.
+   * Referenced by index from `region_groups`.
+   */
+  repeated LoRaPresetGroup groups = 1;
+
+  /*
+   * One entry per known LoRa region, pointing at its preset group.
+   */
+  repeated LoRaRegionPresets region_groups = 2;
 }
 
 /*

--- a/meshtastic/powermon.proto
+++ b/meshtastic/powermon.proto
@@ -22,14 +22,14 @@ message PowerMon {
     CPU_LightSleep = 0x02;
 
     /*
-       The external Vext1 power is on.  Many boards have auxillary power rails that the CPU turns on only
-       occasionally.  In cases where that rail has multiple devices on it we usually want to have logging on
-       the state of that rail as an independent record.
-       For instance on the Heltec Tracker 1.1 board, this rail is the power source for the GPS and screen.
+     The external Vext1 power is on.  Many boards have auxillary power rails that the CPU turns on only
+     occasionally.  In cases where that rail has multiple devices on it we usually want to have logging on
+     the state of that rail as an independent record.
+     For instance on the Heltec Tracker 1.1 board, this rail is the power source for the GPS and screen.
 
-       The log messages will be short and complete (see PowerMon.Event in the protobufs for details).
-       something like "S:PM:C,0x00001234,REASON" where the hex number is the bitmask of all current states.
-       (We use a bitmask for states so that if a log message gets lost it won't be fatal)
+     The log messages will be short and complete (see PowerMon.Event in the protobufs for details).
+     something like "S:PM:C,0x00001234,REASON" where the hex number is the bitmask of all current states.
+     (We use a bitmask for states so that if a log message gets lost it won't be fatal)
     */
     Vext1_On = 0x04;
 


### PR DESCRIPTION
This pull request introduces a new system for communicating which LoRa modem presets are legal in each region from the firmware to clients, allowing client UIs to prevent users from selecting invalid region and preset combinations. The changes add new protobuf messages and options to efficiently encode this mapping, ensuring the data fits within protocol size limits.

**LoRa region and preset compatibility mapping:**

* Added a new `LoRaRegionPresetMap` message to `FromRadio`, sent during the configuration handshake, which describes the valid modem presets for each LoRa region. This enables clients to enforce legal region+preset selections and warn users about licensed-only regions.
* Introduced supporting messages: `LoRaPresetGroup` (describes a set of legal presets, the default preset, and licensing status for regions), and `LoRaRegionPresets` (associates a region with a preset group).
* Documented the structure and rationale for these new messages, including how grouping regions by shared preset lists keeps the mapping compact and fits protocol constraints.

**Protocol size and option constraints:**

* Updated `mesh.options` to define `max_count` and `int_size` for the new fields, ensuring the region-preset map remains within the protocol's maximum message size.