### PR TITLE
chore: adopt buf 1.71 — reformat powermon.proto + pin buf in CI (Renovate-managed)

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Setup Buf
         uses: bufbuild/buf-action@v1.2.0
         with:
+          version: 1.71.0 # renovate: datasource=github-releases depName=bufbuild/buf
           github_token: ${{ github.token }}
           token: ${{ secrets.BUF_TOKEN }}
           setup_only: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Buf PR Checks
         uses: bufbuild/buf-action@v1.2.0
         with:
+          version: 1.71.0 # renovate: datasource=github-releases depName=bufbuild/buf
           github_token: ${{ github.token }}
           token: ${{ secrets.BUF_TOKEN }}
           format: true

--- a/.github/workflows/schema-registry.yml
+++ b/.github/workflows/schema-registry.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Push to schema registry
         uses: bufbuild/buf-action@v1.2.0
         with:
+          version: 1.71.0 # renovate: datasource=github-releases depName=bufbuild/buf
           github_token: ${{ github.token }}
           token: ${{ secrets.BUF_TOKEN }}
           push: true

--- a/meshtastic/powermon.proto
+++ b/meshtastic/powermon.proto
@@ -22,14 +22,14 @@ message PowerMon {
     CPU_LightSleep = 0x02;
 
     /*
-       The external Vext1 power is on.  Many boards have auxillary power rails that the CPU turns on only
-       occasionally.  In cases where that rail has multiple devices on it we usually want to have logging on
-       the state of that rail as an independent record.
-       For instance on the Heltec Tracker 1.1 board, this rail is the power source for the GPS and screen.
+     The external Vext1 power is on.  Many boards have auxillary power rails that the CPU turns on only
+     occasionally.  In cases where that rail has multiple devices on it we usually want to have logging on
+     the state of that rail as an independent record.
+     For instance on the Heltec Tracker 1.1 board, this rail is the power source for the GPS and screen.
 
-       The log messages will be short and complete (see PowerMon.Event in the protobufs for details).
-       something like "S:PM:C,0x00001234,REASON" where the hex number is the bitmask of all current states.
-       (We use a bitmask for states so that if a log message gets lost it won't be fatal)
+     The log messages will be short and complete (see PowerMon.Event in the protobufs for details).
+     something like "S:PM:C,0x00001234,REASON" where the hex number is the bitmask of all current states.
+     (We use a bitmask for states so that if a log message gets lost it won't be fatal)
     */
     Vext1_On = 0x04;
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/.+\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>\\S+)\\s+#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)"
+      ],
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
   ]
 }


### PR DESCRIPTION
Two related buf-CI changes:

### 1. Reformat `powermon.proto` (buf 1.71)
`buf-action` runs the latest `buf` (now **1.71.0**), which normalizes block-comment indentation differently than the version `master` was last formatted with — so the `build` (buf `format`) check fails repo-wide on `meshtastic/powermon.proto`, independent of any content change (`master`'s last green run predated 1.71.0). This applies 1.71's formatting. **Comment-only; no schema change.**

### 2. Pin buf + let Renovate manage it
Root-cause fix so this doesn't recur: the three `bufbuild/buf-action` usages (`pull_request`, `schema-registry`, `create_tag`) now pin `version: 1.71.0` instead of floating to "latest", so the format/lint/breaking checks are deterministic. A `renovate.json` customManager tracks `bufbuild/buf` GitHub releases via the inline `# renovate: datasource=github-releases depName=bufbuild/buf` annotations — so buf bumps arrive as **reviewable Renovate PRs**, and any formatting change lands only when that PR is merged (with the diff visible).

Why the customManager is needed: Renovate's stock `github-actions` manager only bumps the `@v1.2.0` action tag, not the `with: version:` input. Validated with `renovate-config-validator` ✅.

Surfaced while working on #952; kept separate to keep that PR focused. `publish.yml`'s `buf-setup-action` is intentionally left out here (since #952 already edits that file) — can be pinned in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
