### PR TITLE
chore(kmp): bump Kotlin to 2.4.0

### DIFF
--- a/packages/kmp/build.gradle.kts
+++ b/packages/kmp/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "2.3.21"
+    kotlin("multiplatform") version "2.4.0"
     id("com.android.kotlin.multiplatform.library") version "9.2.1"
     id("com.squareup.wire") version "6.4.0"
     id("com.vanniktech.maven.publish") version "0.36.0"


### PR DESCRIPTION
Bumps the KMP package from Kotlin **2.3.21 → 2.4.0**, aligning it with the rest of the meshtastic KMP repos (`meshtastic-sdk`, `MQTTastic-Client-KMP`, `kzstd`, `takpacket-sdk` are all on 2.4.0). protobufs was the last one on 2.3.21; its consumers are already on 2.4.0, so this removes the skew.

## Verification
`./gradlew assemble` builds clean across all targets (JVM, Android, JS, wasmJs/Wasi, macOS/iOS/Linux/Windows/tvOS native) with Wire 6.4.0 — no compatibility issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)