### PR TITLE
ci: include commit hash in KMP snapshot version name

### DIFF
--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - develop
     paths:
       - "meshtastic/**/*.proto"
       - "nanopb.proto"
@@ -19,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Java
         uses: actions/setup-java@v4
@@ -32,8 +33,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Set version name
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0)
+          SHORT_SHA=${GITHUB_SHA::7}
+          echo "VERSION_NAME=${PREV_TAG}-${SHORT_SHA}-SNAPSHOT" >> $GITHUB_ENV
+
       - name: Build KMP package
-        run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ github.ref_name }}-SNAPSHOT
+        run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ env.VERSION_NAME }}
 
       - name: Publish snapshot to Maven Central
         env:
@@ -46,4 +53,4 @@ jobs:
             echo "Missing Maven Central secrets — skipping snapshot publish." >&2
             exit 0
           fi
-          packages/kmp/gradlew --no-daemon -p packages/kmp publishAllPublicationsToMavenCentralRepository -PVERSION_NAME=${{ github.ref_name }}-SNAPSHOT
+          packages/kmp/gradlew --no-daemon -p packages/kmp publishAllPublicationsToMavenCentralRepository -PVERSION_NAME=${{ env.VERSION_NAME }}

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -308,9 +308,7 @@ message ModuleConfig {
     // from the channel's own position_precision ceiling.
     // None of these tags ever shipped in a stable release.
     reserved 1, 2, 3, 5, 7, 10, 12, 13, 14;
-    reserved "enabled", "position_dedup_enabled", "position_precision_bits",
-             "nodeinfo_direct_response", "rate_limit_enabled", "drop_unknown_enabled",
-             "exhaust_hop_telemetry", "exhaust_hop_position", "router_preserve_hops";
+    reserved "enabled", "position_dedup_enabled", "position_precision_bits", "nodeinfo_direct_response", "rate_limit_enabled", "drop_unknown_enabled", "exhaust_hop_telemetry", "exhaust_hop_position", "router_preserve_hops";
 
     /*
      * Minimum interval in seconds between position updates from the same node.


### PR DESCRIPTION
## Summary

- Snapshot version changes from `{branch}-SNAPSHOT` → `{tag}-{shortHash}-SNAPSHOT` (e.g. `v2.7.26-1cba73a-SNAPSHOT`)
- Restricts snapshot publishing to `master` only (removed `develop` trigger)
- Adds `fetch-depth: 0` to checkout so `git describe` can walk back to the nearest tag

## Why

Branch-named snapshots (`develop-SNAPSHOT`) are overwritten on every push and give consumers no way to pin to a specific commit without a full release tag. Including the previous tag + short hash makes each published artifact uniquely addressable and reproducible, while still using the snapshot repository for housekeeping/TTL.

## Reviewer notes

- `git describe --tags --abbrev=0` is used to find the nearest ancestor tag — requires full history, hence `fetch-depth: 0`
- `GITHUB_SHA::7` slices the full SHA to 7 chars in bash (no extra action needed)
- Snapshot-only-on-master means the develop branch no longer publishes; coordinate with any consumers currently depending on `develop-SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)