### PR TITLE
ci: v-strip KMP snapshot version name (no patch bump)

### DIFF
--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -35,9 +35,14 @@ jobs:
 
       - name: Set version name
         run: |
-          PREV_TAG=$(git describe --tags --abbrev=0)
+          # Name the snapshot after the latest tag (v-stripped) plus the short SHA.
+          # The `-<sha>` is a build qualifier, so Maven sorts this ABOVE the tag's
+          # release (no Renovate downgrade) yet below the next release — no patch
+          # bump needed. (The local fallback in build.gradle.kts uses a *bare*
+          # `-SNAPSHOT`, which sorts below its base, so it patch-bumps instead.)
+          BASE=$(git describe --tags --abbrev=0)
           SHORT_SHA=${GITHUB_SHA::7}
-          echo "VERSION_NAME=${PREV_TAG}-${SHORT_SHA}-SNAPSHOT" >> $GITHUB_ENV
+          echo "VERSION_NAME=${BASE#v}-${SHORT_SHA}-SNAPSHOT" >> "$GITHUB_ENV"
 
       - name: Build KMP package
         run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ env.VERSION_NAME }}

--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -18,10 +18,16 @@ The SDK version is derived automatically from the latest git tag — no manual v
 | Context | Version | Source |
 |---------|---------|--------|
 | Release CI (`v2.7.23` tag push) | `2.7.23` | Tag stripped of `v` prefix, passed as `-PVERSION_NAME` |
-| Snapshot CI (`master` push) | `master-SNAPSHOT` | Branch name, passed as `-PVERSION_NAME` |
-| Snapshot CI (`develop` push) | `develop-SNAPSHOT` | Branch name, passed as `-PVERSION_NAME` |
+| Snapshot CI (`master` push) | `2.7.23-497cd88-SNAPSHOT` | Latest tag, `v`-stripped + short commit SHA, passed as `-PVERSION_NAME` |
 | Local dev (no flag) | `2.7.24-SNAPSHOT` | `git describe --tags --abbrev=0` + patch bump |
 | Local override | any | `./gradlew build -PVERSION_NAME=x.y.z` |
+
+CI snapshots keep the tag and append the SHA; local builds instead patch-bump.
+The difference is deliberate: a `-<sha>` suffix is a build qualifier that sorts
+*above* its base version, so CI can name the current tag and still land above
+the release. A *bare* `-SNAPSHOT` sorts *below* its base, so the local fallback
+names the next version to stay ahead of the last release. Both land between the
+last and next release.
 
 If no `-PVERSION_NAME` is supplied and no tag can be resolved (git missing, or a
 shallow/tagless clone), the fallback degrades to `0.0.1-SNAPSHOT` rather than
@@ -52,11 +58,14 @@ implementation("org.meshtastic:protobufs:2.7.23")
 
 ### Snapshots
 
-Snapshot builds are published from `master` and `develop` under the stable
-coordinates `master-SNAPSHOT` and `develop-SNAPSHOT` — pin once and every push
-to that branch republishes the same version. They live in the Central Portal
-snapshots repository, not on the main Maven Central CDN. To consume them, add
-that repository alongside `mavenCentral()`:
+Every push to `master` publishes a snapshot under a unique coordinate of the
+form `{latest-tag}-{short-sha}-SNAPSHOT` (e.g. `2.7.23-497cd88-SNAPSHOT`): the
+latest release tag with its `v` stripped, plus the 7-char commit SHA. The
+`-<sha>` suffix is a build qualifier, so Maven sorts each snapshot *above* the
+release it was built from (dependency bots never propose a downgrade) yet
+*below* the next release. They live in the Central Portal snapshots repository,
+not on the main Maven Central CDN. To consume them, add that repository
+alongside `mavenCentral()`:
 
 ```kotlin
 // settings.gradle.kts (or build.gradle.kts)
@@ -67,18 +76,12 @@ repositories {
   }
 }
 
-// build.gradle.kts
-implementation("org.meshtastic:protobufs:develop-SNAPSHOT")
+// build.gradle.kts — pin a specific published snapshot
+implementation("org.meshtastic:protobufs:2.7.23-497cd88-SNAPSHOT")
 ```
 
-Gradle caches snapshot resolutions for 24 hours by default. To always pick up
-the latest publish during active development:
-
-```kotlin
-configurations.all {
-  resolutionStrategy.cacheChangingModulesFor(0, "minutes")
-}
-```
+Each `master` push produces a new coordinate, so pin a specific one and bump it
+(e.g. via Renovate) as newer snapshots publish.
 
 ## Local build
 


### PR DESCRIPTION
## Problem

The `Set version name` step in `snapshot-kmp.yml` used `git describe --tags --abbrev=0` verbatim, so the published coordinate was `org.meshtastic:protobufs:v2.7.26-<sha>-SNAPSHOT`. The leading **`v`** makes Maven's comparator treat the whole string as a qualifier, sorting it *below every numeric version*. The downstream consumer (Meshtastic-Android pins this exact string in `gradle/libs.versions.toml` and Renovate manages it) got a proposed **downgrade** to the latest plain release.

## Fix

**Strip the leading `v`. No patch bump.**

The original framing of this task assumed `2.7.26-<sha>-SNAPSHOT` would *also* sort below the `2.7.26` release (and so proposed patch-bumping to `2.7.27-<sha>-SNAPSHOT`). Checking against Maven's authoritative `ComparableVersion` (maven-artifact 3.9.16) shows that's **not** how Maven orders these — the `-<sha>` is a build qualifier that sorts *above* the bare release. So the v-stripped, un-bumped coordinate already has the properties we want, and patch-bumping is actively wrong (it sorts the snapshot *above* the next release):

| Comparison | No bump `2.7.26-<sha>-SNAPSHOT` | Patch bump `2.7.27-<sha>-SNAPSHOT` |
|---|---|---|
| vs `2.7.25` (older release) | **>** ✅ | **>** ✅ |
| vs `2.7.26` (release it's built from) | **>** ✅ no downgrade | **>** ✅ |
| vs `2.7.27` (next release) | **<** ✅ clean upgrade when it ships | **>** ❌ blocks the upgrade |

Verified SHA-independent (both digit- and letter-leading SHAs behave the same). `actionlint` passes clean.

The local-build fallback in `packages/kmp/build.gradle.kts` **keeps** its patch bump: it emits a *bare* `-SNAPSHOT`, which Maven sorts *below* its base, so it must name the next version to stay ahead of the last release. CI and local thus diverge for a real reason — documented in the README and the workflow comment so it isn't "fixed" back.

Also updated `packages/kmp/README.md` — the version-derivation table and snapshot consumption docs now describe the `{latest-tag}-{short-sha}-SNAPSHOT` shape (and drop the stale `develop` snapshot row, since the workflow only triggers on `master`).

## ⚠️ Follow-up for the Android consumer

After the next snapshot publishes, the pin in **Meshtastic-Android** (`gradle/libs.versions.toml`) must be re-pinned to the new v-less coordinate (e.g. `2.7.26-<sha>-SNAPSHOT`). Renovate should then track it going forward.

> Known limitation (pre-existing, inherent to embedding a raw SHA, out of scope here): ordering *between* snapshots off the same tag is SHA-arbitrary, so Renovate won't always surface the literal latest commit. A monotonic counter (`git rev-list --count`) would fix that if it ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)