### PR TITLE
Add geofence support to Waypoint (bounding box, circle radius, enter/exit notifications)

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1432,6 +1432,36 @@ message RemoteShell {
 }
 
 /*
+ * A rectangular, axis-aligned geographic bounding box.
+ * Used to define a rectangular geofence region for a Waypoint.
+ * Fields are ordered west, south, east, north to match the standard bounding box
+ * convention used by GeoJSON and PMTiles (min longitude, min latitude, max longitude, max latitude),
+ * so the box can drive an offline map extract directly.
+ * All coordinates are in degrees scaled by 1e-7 (same convention as Position and Waypoint).
+ */
+message BoundingBox {
+  /*
+   * Western edge of the box - minimum longitude (south-west corner)
+   */
+  sfixed32 longitude_west_i = 1;
+
+  /*
+   * Southern edge of the box - minimum latitude (south-west corner)
+   */
+  sfixed32 latitude_south_i = 2;
+
+  /*
+   * Eastern edge of the box - maximum longitude (north-east corner)
+   */
+  sfixed32 longitude_east_i = 3;
+
+  /*
+   * Northern edge of the box - maximum latitude (north-east corner)
+   */
+  sfixed32 latitude_north_i = 4;
+}
+
+/*
  * Waypoint message, used to share arbitrary locations across the mesh
  */
 message Waypoint {
@@ -1475,6 +1505,31 @@ message Waypoint {
    * Designator icon for the waypoint in the form of a unicode emoji
    */
   fixed32 icon = 8;
+
+  /*
+   * If greater than zero, defines a circular geofence centred on this waypoint's
+   * location (latitude_i / longitude_i) with this radius in meters.
+   * Zero means the waypoint has no circular geofence.
+   */
+  uint32 geofence_radius = 9;
+
+  /*
+   * Optional rectangular geofence region for this waypoint.
+   * May be used instead of, or in addition to, geofence_radius.
+   */
+  optional BoundingBox bounding_box = 10;
+
+  /*
+   * If true, a notification should be raised when a tracked node enters this
+   * waypoint's geofence (the circular radius and/or the bounding box).
+   */
+  bool notify_on_enter = 11;
+
+  /*
+   * If true, a notification should be raised when a tracked node exits this
+   * waypoint's geofence (the circular radius and/or the bounding box).
+   */
+  bool notify_on_exit = 12;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Adds an optional geofence capability to `Waypoint`, plus a new `BoundingBox` message, so a waypoint can define a geographic region and nodes can be notified when tracked nodes enter or exit it.

### Schema changes (`meshtastic/mesh.proto`)

**New `BoundingBox` message** — an axis-aligned rectangle defined by its south-west and north-east corners, `sfixed32` degrees ×1e-7 (same convention as `Position`/`Waypoint`). Fields are ordered **west, south, east, north** to match the GeoJSON / PMTiles bbox convention (`minLon, minLat, maxLon, maxLat`), so a waypoint's box maps directly onto an offline map extract.

**`Waypoint` gains four additive fields:**

| Field | # | Purpose |
|---|---|---|
| `geofence_radius` | 9 | Circular geofence centred on the waypoint's own `latitude_i`/`longitude_i`, in meters. `0` = none. |
| `bounding_box` | 10 | Optional rectangular geofence region. |
| `notify_on_enter` | 11 | Raise a notification when a tracked node enters the geofence. |
| `notify_on_exit` | 12 | Raise a notification when a tracked node exits the geofence. |

All changes are additive and backward-compatible (new field numbers 9–12; existing 1–8 untouched). No `.options` changes required — every addition is a fixed-size scalar/bool plus one fixed-size submessage. Verified with `protoc` across the full `meshtastic/*.proto` set.

### Context / reference

Models the app-local geofence feature on the Meshtastic-Apple `feature/geofence-alerts` branch (which has no protobuf layer today and uses a circle only), promoting the geofence region and the enter/exit notification intent into the shared schema and adding the rectangular bounding box. App-wide preferences (default radius, show-on-map, favorites-only filter) remain app-local.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions (no enums added in this PR)
