### PR TITLE
Add notify_favorites_only to Waypoint geofence

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1530,6 +1530,14 @@ message Waypoint {
    * waypoint's geofence (the circular radius and/or the bounding box).
    */
   bool notify_on_exit = 12;
+
+  /*
+   * If true, only raise geofence enter/exit notifications for nodes that are
+   * marked as favorites on the receiving device. Applies to both notify_on_enter
+   * and notify_on_exit. Favorite status is resolved locally per receiver, so the
+   * same waypoint alerts each node only for its own favorites.
+   */
+  bool notify_favorites_only = 13;
 }
 
 /*


### PR DESCRIPTION
# What does this PR do?

Adds a `notify_favorites_only` flag to the `Waypoint` geofence fields.

When set, a waypoint's geofence enter/exit notifications (`notify_on_enter` / `notify_on_exit`) only fire for nodes that are marked as **favorites on the receiving device**. Favorite status is resolved locally per receiver, so it's a shared per-waypoint flag with per-node interpretation — the same model as the existing notify flags.

```proto
message Waypoint {
  ...
  bool notify_on_enter      = 11;
  bool notify_on_exit       = 12;
  bool notify_favorites_only = 13;  // new
}
```

Additive change (field 13); existing fields are untouched and it's wire-compatible. No `.options` change is needed (a `bool` is fixed-size). Verified with `protoc` across the full `meshtastic/*.proto` set.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions (no enums added in this PR)
