### PR TITLE
Add ShortUltra modem preset enum

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1100,6 +1100,14 @@ message Config {
        * Comparable link budget and data rate to LONG_MODERATE.
        */
       TINY_SLOW = 15;
+
+      /*
+       * Short Range - Ultra
+       * Fastest preset with 500kHz bandwidth, SF5, and CR 4/5.
+       * Intended data rate is about 62.5 kbps.
+       * Only compatible with SX126x-family chipsets, including STM32WLx, and LR11xx chipsets.
+       */
+      SHORT_ULTRA = 16;
     }
 
     enum FEM_LNA_Mode {


### PR DESCRIPTION
## Summary
- Add `SHORT_ULTRA = 16` to `Config.LoRaConfig.ModemPreset`.
- Document it as SF5, 500 kHz bandwidth, CR 4/5, about 62.5 kbps.
- Note the intended SX126x-family compatibility, including STM32WLx, plus LR11xx.

## Firmware dependency
Companion firmware draft PR: https://github.com/h3lix1/mesh-firmware-sunl/pull/6

The firmware branch regenerates to the same generated enum value and comment. This PR makes the protobuf source of truth match that generated surface.

## Validation
- `./bin/regen-protos.sh` from the firmware checkout completed with nanopb 0.4.9.1.
- Regeneration produced the expected comment-only update in `src/mesh/generated/meshtastic/config.pb.h` after the STM32WLx wording change.
