### PR TITLE
Add is_unmessagable and is_licensed as fields for DeviceProfile exports

### DIFF
--- a/meshtastic/clientonly.proto
+++ b/meshtastic/clientonly.proto
@@ -55,4 +55,14 @@ message DeviceProfile {
    * Predefined messages for CannedMessage
    */
   optional string canned_messages = 8;
+
+  /*
+   * Is the node unmessagable
+   */
+  optional bool is_unmessagable = 9;
+
+  /*
+   * Is this node in licensed user mode
+   */
+  optional bool is_licensed = 10;
 }


### PR DESCRIPTION
# What does this PR do?

Adds a couple missing fields for device exports using the `DeviceProfile` protobuf. These weren't added and I'd like to have them available for CLI import/export.

> [Related python PR](https://github.com/meshtastic/python/pull/944)

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new optional device profile settings to better describe device capabilities and licensing status.
  * Devices can now be marked as not messageable or as licensed where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->