### PR TITLE
Add transparent_mode to config.proto

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1249,6 +1249,13 @@ message Config {
      * Don't use radiolib to initialize the radio, instead listen for a serialHal connection
      */
     bool serial_hal_only = 107;
+
+    /*
+     * Act as a transparent LoRa modem: run RadioLib on-device but do no encryption, decryption, or mesh routing.
+     * The connected client sets the PHY settings via this LoRaConfig, supplies fully-formed (already-encrypted) frames to transmit verbatim,
+     * and receives every frame the radio hears delivered raw (never decrypted) back over the API.
+     */
+    bool transparent_mode = 108;
   }
 
   message BluetoothConfig {


### PR DESCRIPTION
Adds another potential option for splitting layers with the client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new LoRa configuration option for transparent modem mode.
  * When enabled, the device operates in a pass-through mode that transmits provided pre-encrypted frames verbatim and returns received frames in raw form through the API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->