### PR TITLE
Fix formatting in portnums.proto

### DIFF
--- a/meshtastic/portnums.proto
+++ b/meshtastic/portnums.proto
@@ -265,7 +265,7 @@ enum PortNum {
    * TAKPacketV2 with zstd dictionary compression.
    */
   ATAK_PLUGIN_V2 = 78;
-  
+
   /* signed firmware updates over lora.
    *
    * ENCODING: binary (ota-common transport frames)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up formatting in the port number enum for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->