### PR TITLE
ci: make KMP snapshot versions sort by recency

### DIFF
--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -35,14 +35,16 @@ jobs:
 
       - name: Set version name
         run: |
-          # Name the snapshot after the latest tag (v-stripped) plus the short SHA.
-          # The `-<sha>` is a build qualifier, so Maven sorts this ABOVE the tag's
-          # release (no Renovate downgrade) yet below the next release — no patch
-          # bump needed. (The local fallback in build.gradle.kts uses a *bare*
-          # `-SNAPSHOT`, which sorts below its base, so it patch-bumps instead.)
-          BASE=$(git describe --tags --abbrev=0)
-          SHORT_SHA=${GITHUB_SHA::7}
-          echo "VERSION_NAME=${BASE#v}-${SHORT_SHA}-SNAPSHOT" >> "$GITHUB_ENV"
+          # Name the snapshot after the latest tag (v-stripped) plus the commit
+          # count since that tag and the short SHA, e.g. 2.7.26-82-g678281c-SNAPSHOT.
+          # The count is a *numeric* token, so Maven sorts newer commits ABOVE older
+          # snapshots — consumers' Renovate picks the newest by default, no custom
+          # versioning needed. It still sorts ABOVE the tag's release (no downgrade)
+          # and BELOW the next release. `--long` forces the -<N>-g<sha> suffix even on
+          # a tagged commit, so a bare `-SNAPSHOT` (which sorts below its base) is never
+          # produced. (The local fallback in build.gradle.kts still uses bare `-SNAPSHOT`.)
+          DESCRIBE=$(git describe --tags --long)
+          echo "VERSION_NAME=${DESCRIBE#v}-SNAPSHOT" >> "$GITHUB_ENV"
 
       - name: Build KMP package
         run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ env.VERSION_NAME }}

--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -18,16 +18,17 @@ The SDK version is derived automatically from the latest git tag — no manual v
 | Context | Version | Source |
 |---------|---------|--------|
 | Release CI (`v2.7.23` tag push) | `2.7.23` | Tag stripped of `v` prefix, passed as `-PVERSION_NAME` |
-| Snapshot CI (`master` push) | `2.7.23-497cd88-SNAPSHOT` | Latest tag, `v`-stripped + short commit SHA, passed as `-PVERSION_NAME` |
+| Snapshot CI (`master` push) | `2.7.23-42-g497cd88-SNAPSHOT` | `git describe --tags --long`, `v`-stripped, passed as `-PVERSION_NAME` |
 | Local dev (no flag) | `2.7.24-SNAPSHOT` | `git describe --tags --abbrev=0` + patch bump |
 | Local override | any | `./gradlew build -PVERSION_NAME=x.y.z` |
 
-CI snapshots keep the tag and append the SHA; local builds instead patch-bump.
-The difference is deliberate: a `-<sha>` suffix is a build qualifier that sorts
-*above* its base version, so CI can name the current tag and still land above
-the release. A *bare* `-SNAPSHOT` sorts *below* its base, so the local fallback
-names the next version to stay ahead of the last release. Both land between the
-last and next release.
+CI snapshots keep the tag and append the commit count since it (`N`) plus the
+SHA; local builds instead patch-bump. The difference is deliberate: `-N-g<sha>`
+leads with a *numeric* token, so Maven sorts newer commits above older snapshots
+(dependency bots pick the newest) while the whole coordinate still sorts *above*
+its base release and *below* the next one. A *bare* `-SNAPSHOT` sorts *below* its
+base, so the local fallback names the next version to stay ahead of the last
+release. Both land between the last and next release.
 
 If no `-PVERSION_NAME` is supplied and no tag can be resolved (git missing, or a
 shallow/tagless clone), the fallback degrades to `0.0.1-SNAPSHOT` rather than
@@ -59,11 +60,12 @@ implementation("org.meshtastic:protobufs:2.7.23")
 ### Snapshots
 
 Every push to `master` publishes a snapshot under a unique coordinate of the
-form `{latest-tag}-{short-sha}-SNAPSHOT` (e.g. `2.7.23-497cd88-SNAPSHOT`): the
-latest release tag with its `v` stripped, plus the 7-char commit SHA. The
-`-<sha>` suffix is a build qualifier, so Maven sorts each snapshot *above* the
-release it was built from (dependency bots never propose a downgrade) yet
-*below* the next release. They live in the Central Portal snapshots repository,
+form `{latest-tag}-{N}-g{short-sha}-SNAPSHOT` (e.g. `2.7.23-42-g497cd88-SNAPSHOT`):
+`git describe --tags --long` with the `v` stripped — the latest release tag, the
+commit count `N` since that tag, and the 7-char commit SHA. The leading numeric
+`N` makes Maven sort newer commits *above* older snapshots (dependency bots pick
+the newest and never propose a downgrade) while each snapshot still sorts *above*
+the release it was built from yet *below* the next release. They live in the Central Portal snapshots repository,
 not on the main Maven Central CDN. To consume them, add that repository
 alongside `mavenCentral()`:
 
@@ -77,7 +79,7 @@ repositories {
 }
 
 // build.gradle.kts — pin a specific published snapshot
-implementation("org.meshtastic:protobufs:2.7.23-497cd88-SNAPSHOT")
+implementation("org.meshtastic:protobufs:2.7.23-42-g497cd88-SNAPSHOT")
 ```
 
 Each `master` push produces a new coordinate, so pin a specific one and bump it


### PR DESCRIPTION
## Why

The `Publish KMP snapshot` workflow names each snapshot `<tag>-<shortsha>-SNAPSHOT` (e.g. `2.7.26-678281c-SNAPSHOT`). A git short SHA carries no chronological signal, and Maven's `ComparableVersion` tokenizes it as alpha/numeric garbage. Two consequences for downstream consumers:

- **Renovate can't identify the newest snapshot.** It sorts candidates with Maven's algorithm, so "latest" resolves to latest-*lexical*, not latest-*commit* — and frequently proposes a bump **backwards** to an older commit. E.g. `2.7.26-aa53c96-SNAPSHOT` (older, commit #80) sorts *above* `2.7.26-678281c-SNAPSHOT` (newer, commit #82) because the string token `aa` compares differently than the numeric-leading `678281`.
- Ordering between any two SHAs is effectively random w.r.t. time (a hex SHA leads with a digit or a letter arbitrarily).

## What

Replace `git describe --tags --abbrev=0` + `${GITHUB_SHA::7}` with a single `git describe --tags --long`, producing `<tag>-<N>-g<shortsha>-SNAPSHOT` (e.g. `2.7.26-82-g678281c-SNAPSHOT`), where **N is the commit count since the tag**.

`N` is a leading **numeric** token, which Maven compares numerically — so newer commits sort above older snapshots and consumers' Renovate picks the newest **with no custom versioning config**.

## Invariants preserved

- **Sorts above the tag's release** (`2.7.26-82-g… > 2.7.26`) — no Renovate downgrade once a release is published.
- **Sorts below the next release** (`… < 2.7.27`).
- **No bare `-SNAPSHOT`.** `--long` forces the `-<N>-g<sha>` suffix even when HEAD is exactly on a tag, so the version never collapses to `2.7.26-SNAPSHOT` (which would sort *below* its base and cause a downgrade).
- **Transition is a clean upgrade.** The first publish under this scheme sorts above the current `-<sha>-SNAPSHOT` pins (numeric token `82` > string token `aa`), so consumers see it as a normal bump.

## Notes

- `fetch-depth: 0` is already set on the checkout, so full history + tags are available for the commit count.
- The local fallback in `build.gradle.kts` still uses a bare `-SNAPSHOT` (unchanged — local dev builds don't need cross-snapshot ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated snapshot versioning in the snapshot CI process to use a tag-with-distance format plus a commit identifier, producing more consistent snapshot coordinates.
  * Improved Maven snapshot version ordering behavior to avoid ambiguous bare `-SNAPSHOT` versions.
* **Documentation**
  * Updated the Kotlin Multiplatform README to reflect the new snapshot coordinate format and sorting/pinning examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->