### PR TITLE
ci: separate snapshot count with a dot so it outranks legacy SHA snapshots

### DIFF
--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -8,6 +8,9 @@ on:
       - "meshtastic/**/*.proto"
       - "nanopb.proto"
       - "packages/kmp/**"
+  # Allow republishing on demand (e.g. after a versioning-scheme change that
+  # touches only this workflow, which the push paths above don't match).
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -35,16 +38,26 @@ jobs:
 
       - name: Set version name
         run: |
-          # Name the snapshot after the latest tag (v-stripped) plus the commit
-          # count since that tag and the short SHA, e.g. 2.7.26-82-g678281c-SNAPSHOT.
-          # The count is a *numeric* token, so Maven sorts newer commits ABOVE older
-          # snapshots — consumers' Renovate picks the newest by default, no custom
-          # versioning needed. It still sorts ABOVE the tag's release (no downgrade)
-          # and BELOW the next release. `--long` forces the -<N>-g<sha> suffix even on
-          # a tagged commit, so a bare `-SNAPSHOT` (which sorts below its base) is never
-          # produced. (The local fallback in build.gradle.kts still uses bare `-SNAPSHOT`.)
-          DESCRIBE=$(git describe --tags --long)
-          echo "VERSION_NAME=${DESCRIBE#v}-SNAPSHOT" >> "$GITHUB_ENV"
+          # Name the snapshot after the latest tag (v-stripped), the commit count
+          # since that tag, and the short SHA, e.g. 2.7.26.88-gd77b460-SNAPSHOT.
+          #
+          # The count goes after a DOT, not a hyphen, and that is load-bearing. In
+          # Maven's ComparableVersion a dot-separated numeric segment outranks ANY
+          # hyphen-nested token, so these sort ABOVE the legacy `<tag>-<sha>-SNAPSHOT`
+          # snapshots still in the repo — whose SHA can tokenize to a huge integer
+          # (e.g. 678281c -> 678281) that would otherwise dwarf the count and mask
+          # every new snapshot from dependency bots. Among themselves, higher count =
+          # newer commit sorts higher, so bots pick the newest. Still sorts ABOVE the
+          # tag's release (no downgrade) and BELOW the next release. `--long` forces
+          # the -<N>-g<sha> suffix even on a tagged commit, so a bare `-SNAPSHOT`
+          # (which sorts below its base) is never produced. (Local fallback in
+          # build.gradle.kts still uses bare `-SNAPSHOT`.)
+          #
+          # Parsed right-to-left (describe = <tag>-<N>-g<sha>) so a hyphenated tag
+          # like v1.2.3-rc1 would still split correctly.
+          DESCRIBE=$(git describe --tags --long); DESCRIBE=${DESCRIBE#v}
+          SHA=${DESCRIBE##*-}; REST=${DESCRIBE%-*}; COUNT=${REST##*-}; TAG=${REST%-*}
+          echo "VERSION_NAME=${TAG}.${COUNT}-${SHA}-SNAPSHOT" >> "$GITHUB_ENV"
 
       - name: Build KMP package
         run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=${{ env.VERSION_NAME }}

--- a/packages/kmp/README.md
+++ b/packages/kmp/README.md
@@ -18,17 +18,20 @@ The SDK version is derived automatically from the latest git tag — no manual v
 | Context | Version | Source |
 |---------|---------|--------|
 | Release CI (`v2.7.23` tag push) | `2.7.23` | Tag stripped of `v` prefix, passed as `-PVERSION_NAME` |
-| Snapshot CI (`master` push) | `2.7.23-42-g497cd88-SNAPSHOT` | `git describe --tags --long`, `v`-stripped, passed as `-PVERSION_NAME` |
+| Snapshot CI (`master` push) | `2.7.23.42-g497cd88-SNAPSHOT` | `git describe --tags --long`, `v`-stripped, count after a dot, passed as `-PVERSION_NAME` |
 | Local dev (no flag) | `2.7.24-SNAPSHOT` | `git describe --tags --abbrev=0` + patch bump |
 | Local override | any | `./gradlew build -PVERSION_NAME=x.y.z` |
 
 CI snapshots keep the tag and append the commit count since it (`N`) plus the
-SHA; local builds instead patch-bump. The difference is deliberate: `-N-g<sha>`
-leads with a *numeric* token, so Maven sorts newer commits above older snapshots
-(dependency bots pick the newest) while the whole coordinate still sorts *above*
-its base release and *below* the next one. A *bare* `-SNAPSHOT` sorts *below* its
-base, so the local fallback names the next version to stay ahead of the last
-release. Both land between the last and next release.
+SHA; local builds instead patch-bump. The count goes after a *dot* (`{tag}.{N}`),
+which is deliberate: in Maven's ordering a dot-separated numeric segment outranks
+any hyphen-nested token, so a newer commit's higher count sorts above older
+snapshots — including legacy `{tag}-{sha}-SNAPSHOT` builds still in the repo whose
+SHA can tokenize to a large integer — while the whole coordinate still sorts
+*above* its base release and *below* the next one. Dependency bots therefore pick
+the newest. A *bare* `-SNAPSHOT` sorts *below* its base, so the local fallback
+names the next version to stay ahead of the last release. Both land between the
+last and next release.
 
 If no `-PVERSION_NAME` is supplied and no tag can be resolved (git missing, or a
 shallow/tagless clone), the fallback degrades to `0.0.1-SNAPSHOT` rather than
@@ -60,12 +63,14 @@ implementation("org.meshtastic:protobufs:2.7.23")
 ### Snapshots
 
 Every push to `master` publishes a snapshot under a unique coordinate of the
-form `{latest-tag}-{N}-g{short-sha}-SNAPSHOT` (e.g. `2.7.23-42-g497cd88-SNAPSHOT`):
+form `{latest-tag}.{N}-g{short-sha}-SNAPSHOT` (e.g. `2.7.23.42-g497cd88-SNAPSHOT`):
 `git describe --tags --long` with the `v` stripped — the latest release tag, the
-commit count `N` since that tag, and the 7-char commit SHA. The leading numeric
-`N` makes Maven sort newer commits *above* older snapshots (dependency bots pick
-the newest and never propose a downgrade) while each snapshot still sorts *above*
-the release it was built from yet *below* the next release. They live in the Central Portal snapshots repository,
+commit count `N` since that tag (after a **dot**), and the 7-char commit SHA. The
+dot-separated numeric `N` outranks any hyphen-nested token in Maven's ordering, so
+newer commits sort *above* older snapshots — including legacy `{tag}-{sha}` builds
+still in the repo — letting dependency bots pick the newest and never downgrade,
+while each snapshot still sorts *above* the release it was built from yet *below*
+the next release. They live in the Central Portal snapshots repository,
 not on the main Maven Central CDN. To consume them, add that repository
 alongside `mavenCentral()`:
 
@@ -79,7 +84,7 @@ repositories {
 }
 
 // build.gradle.kts — pin a specific published snapshot
-implementation("org.meshtastic:protobufs:2.7.23-42-g497cd88-SNAPSHOT")
+implementation("org.meshtastic:protobufs:2.7.23.42-g497cd88-SNAPSHOT")
 ```
 
 Each `master` push produces a new coordinate, so pin a specific one and bump it


### PR DESCRIPTION
## Why

Follow-up to #977. That switched snapshots to `git describe --tags --long` → `{tag}-{N}-g{sha}-SNAPSHOT` so the commit count `N` orders them. It fixed ordering **among new snapshots**, but missed the interaction with the **legacy `{tag}-{sha}-SNAPSHOT` snapshots still published in the repo**.

The count sits at the same hyphen level as an old SHA. A 7-char short SHA can tokenize to a large integer — e.g. `678281c` → **678281** — which dwarfs the count (e.g. **88**). So in Maven's `ComparableVersion`, the legacy snapshot still sorts highest and dependency bots keep pointing at it. The new scheme is **masked and never picked**, and won't be until the legacy snapshots prune (weeks).

Verified with `maven-artifact` 3.9.9 (ascending):

```
2.7.26-aa53c96-SNAPSHOT
2.7.26-88-gd77b460-SNAPSHOT     ← new scheme (#977) — masked
2.7.26-93b6436-SNAPSHOT
2.7.26-21879a9-SNAPSHOT
2.7.26-678281c-SNAPSHOT         ← legacy = still "latest"
```

## What

Move the count after a **dot**: `{tag}.{N}-g{sha}-SNAPSHOT` (e.g. `2.7.26.88-gd77b460-SNAPSHOT`).

A dot-separated numeric segment **categorically outranks any hyphen-nested token** in Maven's ordering, so the new snapshots sort above every legacy `-<sha>-SNAPSHOT` regardless of the SHA's leading digits — not by luck. Verified:

```
2.7.26-678281c-SNAPSHOT  <  2.7.26.88-gd77b460-SNAPSHOT  <  2.7.27
```

Invariants preserved: sorts above the tag's release, below the next release, orders among itself by count, and `--long` keeps the `-<N>-g<sha>` suffix so a bare `-SNAPSHOT` is never emitted. Parsing is right-to-left, so a hyphenated tag (`v1.2.3-rc1`) still splits correctly.

## Also

Adds `workflow_dispatch` — this scheme change touches only the workflow file, which the push-path filter (`*.proto` / `nanopb.proto` / `packages/kmp/**`) doesn't match, so it can't self-publish. After merge, dispatch once to emit the first dot-form snapshot and unstick consumers' Renovate.

Docs (`packages/kmp/README.md`) updated to the dot form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated snapshot versioning documentation and examples to match the latest version format used in CI builds.

* **Chores**
  * Enabled manual triggering for the snapshot build workflow and updated snapshot version naming to be more consistent and traceable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->