### PR TITLE
Add compact chunked client API payload

### DIFF
--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -116,6 +116,8 @@
 *ChunkedPayload.chunk_count int_size:16
 *ChunkedPayload.chunk_index int_size:16
 *ChunkedPayload.payload_chunk max_size:228
+*ClientApiChunkedPayload.payload_size int_size:16
+*ClientApiChunkedPayload.payload_chunk max_size:228
 
 # Longest documented value is "token_wrong_size" (16 chars); 32 leaves room
 # for future short reasons without forcing nanopb to use callbacks.

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2995,8 +2995,9 @@ message ChunkedPayload {
  */
 message ClientApiChunkedPayload {
   /*
-   * The total size of the reassembled payload. This is sent only on the
-   * first chunk of an ordered transfer; later chunks omit it.
+   * The non-zero total size of the reassembled payload. This is sent only
+   * on the first chunk of an ordered transfer; later chunks omit it. Empty
+   * client API messages are not transported in chunked form.
    */
   uint32 payload_size = 1;
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2429,6 +2429,12 @@ message FromRadio {
      * any group carries no constraint info and should not be restricted.
      */
     LoRaRegionPresetMap region_presets = 19;
+
+    /*
+     * Chunked client API payload. Only sent to clients that have opted in to
+     * chunked API transport support.
+     */
+    ClientApiChunkedPayload chunked_payload = 20;
   }
 }
 
@@ -2635,6 +2641,12 @@ message ToRadio {
      * Heartbeat message (used to keep the device connection awake on serial)
      */
     Heartbeat heartbeat = 7;
+
+    /*
+     * Chunked client API payload. The reassembled payload is a serialized
+     * ToRadio message and is handled through the normal PhoneAPI path.
+     */
+    ClientApiChunkedPayload chunked_payload = 8;
   }
 }
 
@@ -2976,6 +2988,22 @@ message ChunkedPayload {
    * The binary data of the current chunk
    */
   bytes payload_chunk = 4;
+}
+
+/*
+ * Compact ordered chunk used to transport serialized client API messages.
+ */
+message ClientApiChunkedPayload {
+  /*
+   * The total size of the reassembled payload. This is sent only on the
+   * first chunk of an ordered transfer; later chunks omit it.
+   */
+  uint32 payload_size = 1;
+
+  /*
+   * The binary data of the current chunk
+   */
+  bytes payload_chunk = 2;
 }
 
 /*


### PR DESCRIPTION
## Summary

Add a compact, ordered `ClientApiChunkedPayload` wrapper for Meshtastic client API transports that must carry serialized `ToRadio` and `FromRadio` messages over small BLE characteristic reads and writes.

The immediate use case is Garmin Connect IQ, where public BLE writes are limited to 20 bytes and ATT long reads are unavailable.

Related firmware implementation: https://github.com/meshtastic/firmware/pull/10928

## What changed

- Adds `ClientApiChunkedPayload.payload_size = 1` as `uint32`, with nanopb `int_size:16`.
- Adds `ClientApiChunkedPayload.payload_chunk = 2` as `bytes`, with nanopb `max_size:228`.
- Adds `ToRadio.chunked_payload = 8`.
- Adds `FromRadio.chunked_payload = 20`.

## Compatibility

This uses a new message type rather than repurposing the existing `ChunkedPayload` schema. The existing four-field `ChunkedPayload` (`payload_id`, `chunk_count`, `chunk_index`, and `payload_chunk`) and `ChunkedPayloadResponse` remain unchanged for their current users.

Existing clients ignore the new `ToRadio` and `FromRadio` fields. Firmware emits chunked responses only after a client has successfully opted in by completing a chunked request.

## Transport behavior

The first chunk carries `payload_size` and `payload_chunk`. Continuation chunks carry only `payload_chunk`. The transport assumes ordered, reliable delivery on one connection, avoiding IDs, counts, and indices in every 20-byte packet.

With the corresponding firmware implementation, a 20-byte transport frame carries 13 bytes in the first `ToRadio` chunk and 16 thereafter, or 12 bytes in the first `FromRadio` chunk and 15 thereafter.

## Validation

- Regenerated firmware nanopb sources reproducibly.
- Compared the firmware's compact outbound encoder byte-for-byte with nanopb at payload totals 21, 127, 128, 511, and 512 bytes.
- Verified every encoded wrapper remains at most 20 bytes and reconstructs the original payload.
- Verified the existing `ChunkedPayload` serialization vector remains `080110021803220104`.
- Built the corresponding firmware for `nrf52_promicro_diy_tcxo` and `heltec-v4`, then completed a live Heltec V4 to Garmin D2 Mach 2 BLE round trip.