### PR TITLE
Add MEDIUM_TURBO modem preset

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1100,6 +1100,13 @@ message Config {
        * Comparable link budget and data rate to LONG_MODERATE.
        */
       TINY_SLOW = 15;
+
+      /*
+       * Medium Range - Turbo
+       * This preset performs similarly to MEDIUM_FAST, but with 500kHz bandwidth.
+       * It is not legal to use in all regions due to this wider bandwidth.
+       */
+      MEDIUM_TURBO = 16;
     }
 
     enum FEM_LNA_Mode {


### PR DESCRIPTION
Adds a new `MEDIUM_TURBO` modem preset (value 16) to `ModemPreset`.

Medium range preset that performs similarly to `MEDIUM_FAST`, but with 500kHz bandwidth. As with the other turbo presets, it is not legal to use in all regions due to this wider bandwidth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Medium Turbo** modem preset for LoRa configuration.
  * Enables users to select an additional performance profile for supported devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->