### PR TITLE
Nz sf region

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -990,6 +990,12 @@ message Config {
        * Check local law!
        */
       ITU2_125CM = 37;
+
+      /*
+       * New Zealand Short Fast
+       * Same band as ANZ, for use with the Short Fast modem preset
+       */
+      NZ_SF = 38;
     }
 
     /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -992,10 +992,10 @@ message Config {
       ITU2_125CM = 37;
 
       /*
-       * New Zealand 924MHz
+       * New Zealand 915MHz-928MHz
        * Same band as ANZ, for use with the Short Fast modem preset
        */
-      NZ_924 = 38;
+      NZ_915 = 38;
     }
 
     /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -992,10 +992,10 @@ message Config {
       ITU2_125CM = 37;
 
       /*
-       * New Zealand Short Fast
+       * New Zealand 924MHz
        * Same band as ANZ, for use with the Short Fast modem preset
        */
-      NZ_SF = 38;
+      NZ_924 = 38;
     }
 
     /*

--- a/meshtastic/mesh.options
+++ b/meshtastic/mesh.options
@@ -102,10 +102,10 @@
 # the 512-byte MAX_TO_FROM_RADIO_SIZE cap. nanopb sizes repeated enums unpacked
 # (~2 bytes/element), so the flat groups + region_groups layout keeps cost additive
 # rather than groups*regions. See bin/regen-protos.sh output for the actual size.
-# region_groups capped at 38 = the number of RegionCode enum values, so it can
+# region_groups capped at 39 = the number of RegionCode enum values, so it can
 # never overflow regardless of how many regions gain a firmware table entry.
 *LoRaRegionPresetMap.groups        max_count:8
-*LoRaRegionPresetMap.region_groups max_count:38
+*LoRaRegionPresetMap.region_groups max_count:39
 *LoRaPresetGroup.presets           max_count:11
 *LoRaRegionPresets.group_index     int_size:8
 

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1809,8 +1809,14 @@ message MeshPacket {
    * Note: this field is _never_ sent on the radio link itself (to save space) Times
    * are typically not sent over the mesh, but they will be added to any Packet
    * (chain of SubPacket) sent to the phone (so the phone can know exact time of reception)
+   * Explicit presence: firmware cannot always attach a trustworthy wall-clock timestamp at the
+   * moment of reception - a node with no GPS and no phone connected yet has no time source at
+   * all. has_rx_time disambiguates that state from a genuine (if coincidental) 1970-01-01
+   * reading. A packet delivered with this field absent may still be re-timestamped once a valid
+   * clock becomes available, before the phone ever sees it - "absent" is not guaranteed
+   * permanent, only "not yet known at last observation".
    */
-  fixed32 rx_time = 7;
+  optional fixed32 rx_time = 7;
 
   /*
    * *Never* sent over the radio links.


### PR DESCRIPTION
Adds a new region specifically for New Zealand to allow the ShortFast preset generally in use there to be the "default" from the start. ANZ is still available for legacy users.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the New Zealand 915–928 MHz LoRa region option, including compatibility with the Short Fast modem preset.
  - Reception timestamps can now explicitly indicate when a timestamp is unavailable, distinguishing that state from a valid zero timestamp.
  - Expanded supported region configuration capacity to accommodate the new regional option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->