### PR TITLE
interdevice: SD card mount, eject and format commands

### DIFF
--- a/meshtastic/interdevice.proto
+++ b/meshtastic/interdevice.proto
@@ -124,6 +124,17 @@ message SdCardInfo {
   // present is not decided yet. Ask again rather than concluding the slot
   // is empty.
   bool busy = 8;
+  // A card answers in the slot but carries no filesystem that could be
+  // mounted (present is false then). Formatting it makes it usable.
+  bool unformatted = 9;
+}
+
+// What to do with the SD card of the co-processor
+enum SdCommand {
+  SD_COMMAND_UNSPECIFIED = 0;
+  SD_MOUNT = 1;  // mount a card that is in the slot, also after an eject
+  SD_EJECT = 2;  // flush and release the card so it can be pulled safely
+  SD_FORMAT = 3; // wipe the card and put a fresh FAT on it, then mount it
 }
 
 // Result of an I2CTransaction
@@ -170,5 +181,10 @@ message InterdeviceMessage {
     // Echoes the id when known, 0 when the frame was undecodable. Never
     // sent in reaction to a nack.
     bool nack = 13;
+    // Request: mount the card, or release it so it can be pulled safely. The
+    // co-processor answers with sd_info. Without an eject the card is mounted
+    // on its own and kept mounted; after one it stays released until a mount
+    // is asked for.
+    SdCommand sd_command = 14;
   }
 }


### PR DESCRIPTION
# What does this PR do?

Follow-up to #721. Adds the SD card control commands the SenseCAP Indicator co-processor bridge needs, so the main firmware can mount, eject and format the card behind the co-processor over the interdevice link.

- `SdCommand` enum (`SD_MOUNT`, `SD_EJECT`, `SD_FORMAT`), carried on a new `sd_command` field (14) of `InterdeviceMessage`. The co-processor answers a command with `sd_info`. Without an eject the card is mounted on its own and kept mounted; after an eject it stays released until a mount is asked for, so it can be pulled safely.
- `unformatted` flag (9) on `SdCardInfo`, so a card that is present but carries no mountable filesystem is told apart from an empty slot.

Additive only: no existing field numbers change, so it is wire compatible with #721. `buf lint` and `buf breaking` pass.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting SD cards that are present but unformatted.
  * Added SD card management operations for mounting, ejecting, and formatting cards.
  * SD card status responses now provide clearer information about filesystem availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->