### PR TITLE
Add HM330X PM sensor

### DIFF
--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -896,6 +896,11 @@ enum TelemetrySensorType {
    * SPA06 pressure and temperature
    */
   SPA06 = 54;
+
+  /*
+   * HM330X PM SENSOR
+   */
+  HM330X = 55;
 }
 
 /*


### PR DESCRIPTION
Adds HM330X PM sensor for FAB26 event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identifying HM330X air-quality sensors in telemetry data.
  * Included documentation for the new sensor type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->