### PR TITLE
2.7: Backport #967 - Rename Seeed Tracker and add SPA06 sensor

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -876,10 +876,10 @@ enum HardwareModel {
   HELTEC_MESH_NODE_T096 = 127;
 
   /*
-   * Seeed studio T1000-E Pro tracker card. NRF52840 w/ LR2021 radio,
+   * Seeed studio Mesh Tracker X1card. NRF52840 w/ LR2021 radio,
    * GPS, button, buzzer, and sensors.
    */
-  TRACKER_T1000_E_PRO = 128;
+  MESH_TRACKER_X1 = 128;
 
   /*
    * Elecrow ThinkNode M7, M8 and M9

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -893,6 +893,11 @@ enum TelemetrySensorType {
   ICM42607P = 53;
 
   /*
+   * SPA06 pressure and temperature
+   */
+  SPA06 = 54;
+
+  /*
    * HM330X PM SENSOR
    */
   HM330X = 55;


### PR DESCRIPTION
Backport changes from #967 to 2.7 branch.
These changes are already present in the generated protobufs in firmware `master` branch. They should be included here too.

This couldn't be cleanly cherrypicked (use squash merge!!!) so simply made the changes manually (copy-paste).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the Mesh Tracker X1 hardware model.
  * Added SPA06 as a recognized telemetry sensor type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->