### PR TITLE
feat: add GPS profile configuration

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -3,6 +3,9 @@
 *DeviceConfig.buzzer_mode int_size:8
 
 
+*PositionConfig.gps_profile int_size:8
+
+
 *NetworkConfig.wifi_ssid max_size:33
 *NetworkConfig.wifi_psk max_size:65
 *NetworkConfig.ntp_server max_size:33

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -275,66 +275,67 @@ message Config {
      * are always included (also time if GPS-synced)
      * NOTE: the more fields are included, the larger the message will be -
      *   leading to longer airtime and a higher risk of packet loss
+     * DEPRECATED in favor of GpsProfile
      */
     enum PositionFlags {
       /*
        * Required for compilation
        */
-      UNSET = 0x0000;
+      UNSET = 0x0000 [deprecated = true];
 
       /*
        * Include an altitude value (if available)
        */
-      ALTITUDE = 0x0001;
+      ALTITUDE = 0x0001 [deprecated = true];
 
       /*
        * Altitude value is MSL
        */
-      ALTITUDE_MSL = 0x0002;
+      ALTITUDE_MSL = 0x0002 [deprecated = true];
 
       /*
        * Include geoidal separation
        */
-      GEOIDAL_SEPARATION = 0x0004;
+      GEOIDAL_SEPARATION = 0x0004 [deprecated = true];
 
       /*
        * Include the DOP value ; PDOP used by default, see below
        */
-      DOP = 0x0008;
+      DOP = 0x0008 [deprecated = true];
 
       /*
        * If POS_DOP set, send separate HDOP / VDOP values instead of PDOP
        */
-      HVDOP = 0x0010;
+      HVDOP = 0x0010 [deprecated = true];
 
       /*
        * Include number of "satellites in view"
        */
-      SATINVIEW = 0x0020;
+      SATINVIEW = 0x0020 [deprecated = true];
 
       /*
        * Include a sequence number incremented per packet
        */
-      SEQ_NO = 0x0040;
+      SEQ_NO = 0x0040 [deprecated = true];
 
       /*
        * Include positional timestamp (from GPS solution)
        */
-      TIMESTAMP = 0x0080;
+      TIMESTAMP = 0x0080 [deprecated = true];
 
       /*
        * Include positional heading
        * Intended for use with vehicle not walking speeds
        * walking speeds are likely to be error prone like the compass
        */
-      HEADING = 0x0100;
+      HEADING = 0x0100 [deprecated = true];
 
       /*
        * Include positional speed
        * Intended for use with vehicle not walking speeds
        * walking speeds are likely to be error prone like the compass
        */
-      SPEED = 0x0200;
+      SPEED = 0x0200 [deprecated = true];
     }
 
     enum GpsMode {
@@ -352,6 +353,28 @@ message Config {
        * GPS is not present on the device
        */
       NOT_PRESENT = 2;
+    }
+
+    /*
+     * A plain language label that users of GPS select based on their intended activity.
+     * Firmware uses this to select GPS update and position broadcast settings, position
+     * flags, and receiver-specific navigation configuration.
+     */
+    enum GpsProfile {
+      /* Profile not set; user controls the individual GPS settings. */
+      MANUAL = 0;
+
+      /* This node does not move. */
+      FIXED_POSITION = 1;
+
+      /* Hikers, runners, walkers. */
+      PEDESTRIAN = 2;
+
+      /* Cars, motorbikes. */
+      VEHICLE = 3;
+
+      /* Planes, balloons, drones. */
+      AIRBORNE = 4;
     }
 
     /*
@@ -392,8 +415,9 @@ message Config {
     /*
      * Bit field of boolean configuration options for POSITION messages
      * (bitwise OR of PositionFlags)
+     * DEPRECATED in favor of GpsProfile
      */
-    uint32 position_flags = 7;
+    uint32 position_flags = 7 [deprecated = true];
 
     /*
      * (Re)define GPS_RX_PIN for your board.
@@ -424,6 +448,9 @@ message Config {
      * Set where GPS is enabled, disabled, or not present
      */
     GpsMode gps_mode = 13;
+
+    /* A pre-tuned GPS configuration selected by use case. */
+    GpsProfile gps_profile = 14;
   }
 
   /*


### PR DESCRIPTION
## Summary
- add the wire-compatible `GpsProfile` enum and `gps_profile = 14`
- retain `position_flags` for compatibility while marking it deprecated
- constrain the new enum to an 8-bit nanopb field

## Validation
- generated `config.pb.h` with nanopb 0.4.9
- `git diff --check`