### PR TITLE
feat: add FAB firmware edition

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2168,6 +2168,11 @@ enum FirmwareEdition {
   HAMVENTION = 19;
 
   /*
+   * FAB, the international Fab Lab digital fabrication conference
+   */
+  FAB = 20;
+
+  /*
    * Placeholder for DIY and unofficial events
    */
   DIY_EDITION = 127;


### PR DESCRIPTION
## Summary

Adds `FAB = 20` to the `FirmwareEdition` enum, the next sequential event slot after `HAMVENTION = 19`.

This lets the Meshtastic app recognize the **FAB26 Boston** event edition — the International Fab Lab Conference & Symposium (July 27–31, 2026, MIT / Cambridge MA). The value is named `FAB` (not year-specific) to match the existing event-name convention (`HAMVENTION`, `DEFCON`, …) and cover future editions of the conference.

## Companion PRs

- **api** — adds the `FAB` edition to the event firmware manifest (`GET resource/eventFirmware`) with brand theme + bundled icon.
- **web-flasher** — adds FAB26 to the bundled offline manifest fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying the FAB firmware edition in device and firmware metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->