### PR TITLE
Add IN_433 regulatory region code

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -990,6 +990,12 @@ message Config {
        * Check local law!
        */
       ITU2_125CM = 37;
+
+      /*
+       * India 433MHz
+       * G.S.R. 347(E), 2022
+       */
+      IN_433 = 38;
     }
 
     /*


### PR DESCRIPTION
# What does this PR do?

Append IN_433 as RegionCode 38 without renumbering existing values. This prepares generated bindings and firmware support for India's 433.05-434.79 MHz allocation under G.S.R. 347(E), 2022.

Regulatory source: https://eservices.dot.gov.in/sites/default/files/circular-notifications/the-use-of-low-power-radio-frequency-devices-in-the-frequency-band-433.05-to-434.79-mhz-exemption-from-license-rules-2022.pdf

Current DoT spectrum-plan context: https://www.dot.gov.in/static/uploads/2026/02/52e468605d5b63c6dfedcf538f1d7d36.pdf

[PDF attached here for easy reference](https://github.com/user-attachments/files/30444163/the-use-of-low-power-radio-frequency-devices-in-the-frequency-band-433.05-to-434.79-mhz-exemption-from-license-rules-2022.pdf).

[UPDATED] Related firmware context: https://github.com/meshtastic/firmware/pull/11268

On why we need a different region configuration:

```
   Existing region    Why it cannot represent India safely
  ━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   ANZ_433            Same frequency range, but permits 14 dBm and 100% duty cycle.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   UA_433             Same 10 dBm/10%, but starts at 433.00 MHz—below India’s 433.05 MHz boundary.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   EU_433             Also starts below the Indian boundary and stops at 434.00 MHz.
  ─────────────────  ───────────────────────────────────────────────────────────────────────────────
   KZ_433             Frequency is a legal subset and power is 10 dBm, but permits 100% duty cycle.
```

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the India 433 MHz regional configuration.
  * Included documentation for the new regional option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->