### PR TITLE
feat: add atomic channel profile protocol

### DIFF
--- a/meshtastic/admin.options
+++ b/meshtastic/admin.options
@@ -16,6 +16,14 @@
 *AdminMessage.set_ringtone_message max_size:231
 *AdminMessage.get_ringtone_response max_size:231
 
+*AdminMessage.ChannelProfile.profile_id max_size:64
+*AdminMessage.ChannelProfile.profile_digest max_size:32
+*AdminMessage.ChannelProfile.channels max_count:8
+*AdminMessage.ChannelProfileResult.profile_id max_size:64
+*AdminMessage.ChannelProfileResult.profile_digest max_size:32
+*AdminMessage.ChannelProfileStatus.applied_profile_id max_size:64
+*AdminMessage.ChannelProfileStatus.applied_profile_digest max_size:32
+
 *HamParameters.call_sign max_size:8
 *HamParameters.short_name max_size:5
 *HamParameters.long_name max_size:15

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -226,6 +226,95 @@ message AdminMessage {
   }
 
   /*
+   * A complete channel profile to apply as one validated operation.
+   *
+   * The profile intentionally contains channels only.  LoRa configuration is
+   * a separate, explicit operation so importing a profile never changes the
+   * radio region, frequency, modem preset, or transmit settings.
+   */
+  message ChannelProfile {
+    enum ApplyMode {
+      /* The client must choose a mode explicitly. */
+      APPLY_MODE_UNSPECIFIED = 0;
+
+      /* Replace the entire channel table after validating the submitted table. */
+      REPLACE = 1;
+
+      /* Preserve the current primary and append compatible profile channels as secondaries. */
+      ADD = 2;
+    }
+
+    /*
+     * A stable, non-secret profile or event identifier.  Firmware echoes it
+     * in ChannelProfileResult so clients can pair a reconnect with the apply
+     * operation that caused it.
+     */
+    string profile_id = 1;
+
+    /*
+     * Opaque, non-secret SHA-256 profile digest supplied by the publisher.
+     * This field is correlation metadata, not a signature or a replacement
+     * for validating the profile at its source.
+     */
+    bytes profile_digest = 2;
+
+    /*
+     * The channels to apply.  REPLACE supplies a complete table with unique
+     * slot indexes and exactly one PRIMARY.  ADD supplies enabled profile
+     * channels; the device chooses vacant slots and stores them as SECONDARY
+     * channels so the current primary and LoRa settings stay unchanged.
+     */
+    repeated Channel channels = 3;
+
+    /* The explicitly selected profile-application behavior. */
+    ApplyMode apply_mode = 4;
+
+    /*
+     * Version of this profile contract.  Version 1 is this schema; devices
+     * reject a newer version instead of partially interpreting it.
+     */
+    uint32 profile_format_version = 5;
+  }
+
+  /*
+   * Result of a channel-profile request.  It contains no channel material or
+   * keys, allowing clients to show completion/reboot state without exporting
+   * sensitive channel settings in a status message.
+   */
+  message ChannelProfileResult {
+    enum Status {
+      STATUS_UNSPECIFIED = 0;
+      APPLIED = 1;
+      INVALID_PROFILE = 2;
+      INSUFFICIENT_CHANNEL_SLOTS = 3;
+      UNSUPPORTED = 4;
+    }
+
+    Status status = 1;
+    string profile_id = 2;
+    bytes profile_digest = 3;
+    uint32 applied_channel_count = 4;
+
+    /* True only when this specific profile operation schedules a reboot. */
+    bool will_reboot = 5;
+  }
+
+  /*
+   * Capability and durable completion state for channel-profile application.
+   * No channel settings or PSKs are returned by this status message.
+   */
+  message ChannelProfileStatus {
+    /* Highest supported ChannelProfile.profile_format_version. */
+    uint32 max_profile_format_version = 1;
+    bool supports_replace = 2;
+    bool supports_add = 3;
+
+    /* Last profile committed with the channel table, if any. */
+    string applied_profile_id = 4;
+    bytes applied_profile_digest = 5;
+  }
+
+  /*
    * TODO: REPLACE
    */
   oneof payload_variant {
@@ -538,6 +627,21 @@ message AdminMessage {
      * to carry passphrase bytes; that hack is retired.
      */
     LockdownAuth lockdown_auth = 104;
+
+    /*
+     * Apply a complete channel profile atomically.  Devices that do not
+     * advertise DeviceMetadata.has_channel_profile must not receive this.
+     */
+    ChannelProfile apply_channel_profile = 105;
+
+    /* Result for an apply_channel_profile request. */
+    ChannelProfileResult channel_profile_result = 106;
+
+    /* Request capability and persisted completion state for channel profiles. */
+    bool get_channel_profile_status_request = 107;
+
+    /* Channel-profile capability and persisted completion state. */
+    ChannelProfileStatus get_channel_profile_status_response = 108;
   }
 }
 

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -5,6 +5,8 @@
 *DeviceState.receive_queue max_count:1
 
 *ChannelFile.channels max_count:8
+*ChannelFile.applied_profile_id max_size:64
+*ChannelFile.applied_profile_digest max_size:32
 
 *DeviceState.node_remote_hardware_pins max_count:12
 

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -315,6 +315,14 @@ message ChannelFile {
    * NodeDB.cpp in the device code.
    */
   uint32 version = 2;
+
+  /*
+   * Completion metadata for the last atomically committed channel profile.
+   * This is non-secret correlation data stored with the channel table so a
+   * reconnect can distinguish a committed operation from an interrupted one.
+   */
+  string applied_profile_id = 3;
+  bytes applied_profile_digest = 4;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2773,6 +2773,12 @@ message DeviceMetadata {
    * This is a read-only capability and must be false when XEdDSA is not compiled in.
    */
   bool has_xeddsa = 14;
+
+  /*
+   * Supports AdminMessage.apply_channel_profile: an atomic, channels-only
+   * profile operation with explicit REPLACE or ADD semantics.
+   */
+  bool has_channel_profile = 15;
 }
 
 /*


### PR DESCRIPTION
## Summary
- add a versioned, channels-only `AdminMessage.ChannelProfile` request with explicit `REPLACE` and `ADD` intent
- add a PSK-free completion/status response, including explicit reboot state
- advertise capability through `DeviceMetadata` and persist the applied profile ID/digest with `ChannelFile`
- add a status query so clients can verify an apply after reconnect

## Constraints
- no LoRa field exists in the profile payload
- `APPLY_MODE_UNSPECIFIED` is invalid; UI defaults to Replace but must send it explicitly
- profile ID/digest are non-secret correlation metadata, not signature verification

## Verification
- `buf format --diff --exit-code`
- `buf lint`
- `buf breaking --against .git#branch=master`

This is a dependency draft for firmware#11109 and the on-device event profile restore work in meshtastic/firmware#11110. Related issue: #1012.