### PR TITLE
ci: auto-publish every package when a release tag is cut

### DIFF
--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -1,7 +1,12 @@
 name: Create tag
 
+# contents: write — create the release/tag (increment_version).
+# id-token: write — required by the called publish.yml for JSR OIDC / npm
+#   provenance. A reusable workflow cannot exceed the caller's token scope,
+#   so it must be granted here even though create_tag itself doesn't use it.
 permissions:
   contents: write
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -18,6 +23,8 @@ on:
 jobs:
   increment_version:
     runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.NEW_VERSION }}
 
     steps:
       - name: Checkout code
@@ -70,3 +77,24 @@ jobs:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
         run: |
           buf push --tag ${{ steps.version.outputs.NEW_VERSION }}
+
+  # The tag above is created with GITHUB_TOKEN, which by design does NOT fire
+  # the `push: tags` trigger on the publish workflows (GitHub's recursion
+  # guard). Before this, publishing depended on someone manually dispatching
+  # each publish workflow — and when that was missed, an artifact silently
+  # lagged its tag (org.meshtastic:protobufs sat at 2.7.25 while v2.7.26 was
+  # tagged). Invoke the publishers directly instead so every tag publishes
+  # every package.
+  publish-npm:
+    needs: increment_version
+    uses: ./.github/workflows/publish.yml
+    with:
+      version: ${{ needs.increment_version.outputs.new_version }}
+    secrets: inherit
+
+  publish-kmp:
+    needs: increment_version
+    uses: ./.github/workflows/publish-kmp.yml
+    with:
+      version: ${{ needs.increment_version.outputs.new_version }}
+    secrets: inherit

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -1,12 +1,8 @@
 name: Create tag
 
-# contents: write — create the release/tag (increment_version).
-# id-token: write — required by the called publish.yml for JSR OIDC / npm
-#   provenance. A reusable workflow cannot exceed the caller's token scope,
-#   so it must be granted here even though create_tag itself doesn't use it.
+# Least privilege: default read-only, each job grants only what it needs.
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 on:
   workflow_dispatch:
@@ -23,6 +19,8 @@ on:
 jobs:
   increment_version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release + tag
     outputs:
       new_version: ${{ steps.version.outputs.NEW_VERSION }}
 
@@ -64,19 +62,9 @@ jobs:
           generateReleaseNotes: true
           token: ${{ github.token }}
 
-      - name: Setup Buf
-        uses: bufbuild/buf-action@v1.4.0
-        with:
-          version: 1.72.0 # renovate: datasource=github-releases depName=bufbuild/buf
-          github_token: ${{ github.token }}
-          token: ${{ secrets.BUF_TOKEN }}
-          setup_only: true
-
-      - name: Push to schema registry
-        env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: |
-          buf push --tag ${{ steps.version.outputs.NEW_VERSION }}
+      # The Buf schema-registry push previously lived here. It now runs in
+      # publish.yml's push-buf-registry job (invoked below), so keeping it
+      # here too would push the same tag to Buf twice per release.
 
   # The tag above is created with GITHUB_TOKEN, which by design does NOT fire
   # the `push: tags` trigger on the publish workflows (GitHub's recursion
@@ -84,9 +72,12 @@ jobs:
   # each publish workflow — and when that was missed, an artifact silently
   # lagged its tag (org.meshtastic:protobufs sat at 2.7.25 while v2.7.26 was
   # tagged). Invoke the publishers directly instead so every tag publishes
-  # every package.
+  # every package. publish.yml also owns the Buf schema-registry push.
   publish-npm:
     needs: increment_version
+    permissions:
+      contents: write # create-release + upload assets
+      id-token: write # JSR OIDC / npm provenance
     uses: ./.github/workflows/publish.yml
     with:
       version: ${{ needs.increment_version.outputs.new_version }}
@@ -94,6 +85,8 @@ jobs:
 
   publish-kmp:
     needs: increment_version
+    permissions:
+      contents: read
     uses: ./.github/workflows/publish-kmp.yml
     with:
       version: ${{ needs.increment_version.outputs.new_version }}

--- a/.github/workflows/publish-kmp.yml
+++ b/.github/workflows/publish-kmp.yml
@@ -15,6 +15,20 @@ on:
         required: false
         type: boolean
         default: false
+  # Called by create_tag.yml right after a release tag is cut. Tags created
+  # with GITHUB_TOKEN do not fire the `push: tags` trigger above (GitHub's
+  # recursion guard), so the release flow invokes this workflow directly.
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish (e.g. v1.2.3)."
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run mode - build and publish to Maven Local only"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,20 @@ on:
         required: false
         type: boolean
         default: false
+  # Called by create_tag.yml right after a release tag is cut. Tags created
+  # with GITHUB_TOKEN do not fire the `push: tags` trigger above (GitHub's
+  # recursion guard), so the release flow invokes this workflow directly.
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to publish (e.g. v1.2.3)."
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run mode - generate artifacts without publishing"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## Problem

`org.meshtastic:protobufs` (the KMP artifact consumed by meshtastic-sdk and TAKPacket-SDK) is **a release behind**: Maven Central serves 2.7.25, but the repo has been tagged **v2.7.26** since 2026-06-20. The npm package is correctly at 2.7.26.

**Root cause:** `create_tag.yml` creates the release tag with `GITHUB_TOKEN`. GitHub's recursion guard means a tag pushed by `GITHUB_TOKEN` does **not** fire the `push: tags` trigger on `publish.yml` / `publish-kmp.yml`. Those triggers are effectively dead — publishing has silently depended on a human remembering to `workflow_dispatch` each publisher after every release. For v2.7.26 the npm publish was hand-dispatched but the KMP one was missed, and nothing surfaced the gap.

## Fix

- **`workflow_call` trigger** added to `publish.yml` and `publish-kmp.yml`. Their version/`dry_run` resolution already reads `inputs.*`, so `workflow_call` populates the same inputs with **no job changes**.
- **`create_tag.yml` calls both publishers** via `uses:` after cutting the tag (`secrets: inherit`, version passed through).
- **`id-token: write`** granted at `create_tag` level — a reusable workflow can't exceed the caller's token scope, and `publish.yml` needs it for JSR OIDC / npm provenance.

Existing `push: tags` + `workflow_dispatch` triggers are preserved, so manual dispatch (and any future PAT-pushed tag) still works.

## Notes for reviewers

- All three workflows validated as YAML.
- The **2.7.26 KMP artifact still needs a one-time manual publish** to catch up — this PR only fixes future releases (handled separately; a 2.7.26 dry-run build was validated first).
- Chose reusable-workflow (`workflow_call`) over `gh workflow run` dispatch deliberately: a `GITHUB_TOKEN` `workflow_dispatch` is subject to the same recursion guard and could silently no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows can now directly publish JavaScript and Kotlin packages after version updates.
  * Added support for reusable publishing workflows with version and dry-run options.
  * Enabled OIDC-based authentication for downstream publishing.

* **Improvements**
  * Publishing is now coordinated directly within the release process, improving reliability and avoiding trigger-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->