### PR TITLE
docs: fix broken CI badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meshtastic Protobuf Definitions
 
-[![CI](https://img.shields.io/github/actions/workflow/status/meshtastic/protobufs/ci.yml?branch=master&label=actions&logo=github&color=yellow)](https://github.com/meshtastic/protobufs/actions/workflows/ci.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/meshtastic/protobufs/pull_request.yml?branch=master&label=actions&logo=github&color=yellow)](https://github.com/meshtastic/protobufs/actions/workflows/pull_request.yml)
 [![CLA assistant](https://cla-assistant.io/readme/badge/meshtastic/protobufs)](https://cla-assistant.io/meshtastic/protobufs)
 [![Fiscal Contributors](https://opencollective.com/meshtastic/tiers/badge.svg?label=Fiscal%20Contributors&color=deeppink)](https://opencollective.com/meshtastic/)
 [![Vercel](https://img.shields.io/static/v1?label=Powered%20by&message=Vercel&style=flat&logo=vercel&color=000000)](https://vercel.com?utm_source=meshtastic&utm_campaign=oss)


### PR DESCRIPTION
## Summary

Fixes the root README's CI badge, which pointed at a nonexistent `ci.yml` workflow (so it rendered as an error). Points it at `pull_request.yml`, the repo's actual PR workflow.

## Type of change

- [x] Documentation only

## Context

This PR originally also fixed the KMP release-publish trigger, but that root cause — tags created by `GITHUB_TOKEN` don't fire `push: tags` — is already handled, more comprehensively, by **#1014** (which fixes all publishers: JSR/npm + KMP, via `workflow_call`). Re-scoped to just the README badge fix to avoid duplicating #1014.

## Verification

Badge target `pull_request.yml` confirmed present in `.github/workflows/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
