### PR TITLE
ci(kmp): add remote HTTP build cache and Konan toolchain caching

### DIFF
--- a/.github/workflows/kmp-pull-request.yml
+++ b/.github/workflows/kmp-pull-request.yml
@@ -10,6 +10,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
 jobs:
   build-kmp:
     runs-on: macos-latest
@@ -28,6 +33,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Cache Konan (Kotlin/Native toolchain)
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('packages/kmp/build.gradle.kts', 'packages/kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Build KMP package
         run: packages/kmp/gradlew --no-daemon -p packages/kmp build -PVERSION_NAME=0.0.0-pr

--- a/.github/workflows/publish-kmp.yml
+++ b/.github/workflows/publish-kmp.yml
@@ -19,6 +19,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
 jobs:
   build-kmp:
     runs-on: macos-latest
@@ -59,6 +64,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Cache Konan (Kotlin/Native toolchain)
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('packages/kmp/build.gradle.kts', 'packages/kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
+
       - name: Build KMP package
         run: packages/kmp/gradlew --no-daemon -p packages/kmp clean build -PVERSION_NAME=${{ steps.version.outputs.VERSION }}
 
@@ -86,6 +99,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Cache Konan (Kotlin/Native toolchain)
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('packages/kmp/build.gradle.kts', 'packages/kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Publish to Maven Central
         env:

--- a/.github/workflows/snapshot-kmp.yml
+++ b/.github/workflows/snapshot-kmp.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: read
 
+env:
+  GRADLE_CACHE_URL: ${{ secrets.GRADLE_CACHE_URL }}
+  GRADLE_CACHE_USERNAME: ${{ secrets.GRADLE_CACHE_USERNAME }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
 jobs:
   publish-snapshot:
     runs-on: macos-latest
@@ -35,6 +40,14 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
+
+      - name: Cache Konan (Kotlin/Native toolchain)
+        uses: actions/cache@v6
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('packages/kmp/build.gradle.kts', 'packages/kmp/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            konan-${{ runner.os }}-
 
       - name: Set version name
         run: |

--- a/packages/kmp/gradle/build-cache.settings.gradle
+++ b/packages/kmp/gradle/build-cache.settings.gradle
@@ -1,0 +1,56 @@
+/*
+ * Shared remote HTTP Gradle build cache for Meshtastic KMP libraries.
+ *
+ * Credentials come from the GRADLE_CACHE_URL / GRADLE_CACHE_USERNAME /
+ * GRADLE_CACHE_PASSWORD environment variables (CI secrets), or a
+ * local.properties / config.properties entry for local use. Push is enabled
+ * only when credentials are present, so fork PRs (which have no secrets) are
+ * pull-only and cannot poison the cache.
+ */
+
+def getMeshProperty(String key) {
+    def env = System.getenv(key)
+    if (env) return env
+    def currentDir = settingsDir
+    while (currentDir != null) {
+        for (name in ["local.properties", "config.properties"]) {
+            def f = new File(currentDir, name)
+            if (f.exists()) {
+                def props = new Properties()
+                f.withInputStream { props.load(it) }
+                if (props.containsKey(key)) return props.getProperty(key)
+            }
+        }
+        currentDir = currentDir.parentFile
+    }
+    return null
+}
+
+buildCache {
+    local {
+        enabled = true
+    }
+    remote(HttpBuildCache) {
+        // Some cache servers return 403 on "Expect: 100-continue".
+        useExpectContinue = false
+        def cacheUrl = getMeshProperty("GRADLE_CACHE_URL")?.trim()
+        def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
+        def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
+        if (cacheUrl) {
+            url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
+            if (cacheUsername && cachePassword) {
+                credentials {
+                    username = cacheUsername
+                    password = cachePassword
+                }
+            }
+            allowInsecureProtocol = true
+            allowUntrustedServer = true
+            // Push only when credentials exist -> fork PRs are pull-only.
+            push = (cacheUsername && cachePassword)
+            enabled = true
+        } else {
+            enabled = false
+        }
+    }
+}

--- a/packages/kmp/gradle/build-cache.settings.gradle
+++ b/packages/kmp/gradle/build-cache.settings.gradle
@@ -3,9 +3,10 @@
  *
  * Credentials come from the GRADLE_CACHE_URL / GRADLE_CACHE_USERNAME /
  * GRADLE_CACHE_PASSWORD environment variables (CI secrets), or a
- * local.properties / config.properties entry for local use. Push is enabled
- * only when credentials are present, so fork PRs (which have no secrets) are
- * pull-only and cannot poison the cache.
+ * local.properties / config.properties entry for local use. Writes to the
+ * cache happen only from trusted events (local dev, push, merge_group) with
+ * credentials present, so pull-request runs (and credential-less fork PRs)
+ * stay pull-only and cannot poison the cache.
  */
 
 def getMeshProperty(String key) {
@@ -37,6 +38,9 @@ buildCache {
         def cacheUsername = getMeshProperty("GRADLE_CACHE_USERNAME")?.trim()
         def cachePassword = getMeshProperty("GRADLE_CACHE_PASSWORD")?.trim()
         if (cacheUrl) {
+            // HTTPS + valid TLS enforced (no allowInsecureProtocol / no
+            // allowUntrustedServer): the cache server must present a trusted
+            // certificate over TLS.
             url = cacheUrl.endsWith("/") ? cacheUrl : "${cacheUrl}/"
             if (cacheUsername && cachePassword) {
                 credentials {
@@ -44,10 +48,12 @@ buildCache {
                     password = cachePassword
                 }
             }
-            allowInsecureProtocol = true
-            allowUntrustedServer = true
-            // Push only when credentials exist -> fork PRs are pull-only.
-            push = (cacheUsername && cachePassword)
+            // Write only from trusted events (local dev, push to a protected
+            // branch, or the merge queue) with credentials — never from
+            // pull_request runs, so unmerged code can't poison the cache.
+            def eventName = System.getenv("GITHUB_EVENT_NAME")
+            def trustedForPush = eventName == null || eventName == "push" || eventName == "merge_group"
+            push = (cacheUsername && cachePassword && trustedForPush)
             enabled = true
         } else {
             enabled = false

--- a/packages/kmp/settings.gradle.kts
+++ b/packages/kmp/settings.gradle.kts
@@ -13,4 +13,6 @@ dependencyResolutionManagement {
     }
 }
 
+apply(from = "gradle/build-cache.settings.gradle")
+
 rootProject.name = "protobufs"


### PR DESCRIPTION
## Summary

Adds Gradle build-cache reuse for the `packages/kmp` artifact, which compiles all 14 KMP targets (incl. native) on macOS in every KMP workflow.

## What changed

- **`packages/kmp/gradle/build-cache.settings.gradle`** (new): shared remote **HTTP build cache**, applied from `packages/kmp/settings.gradle.kts`, configured from `GRADLE_CACHE_URL` / `GRADLE_CACHE_USERNAME` / `GRADLE_CACHE_PASSWORD` (CI secrets; nothing hardcoded). Push only with credentials → fork PRs are pull-only and can't poison the cache.
- **`~/.konan` caching** (`actions/cache@v6`) added to `kmp-pull-request.yml`, `snapshot-kmp.yml`, and both jobs of `publish-kmp.yml` — keyed on `build.gradle.kts` + wrapper. Today every run re-downloads the Kotlin/Native toolchain from cold.
- `GRADLE_CACHE_*` env wired into all three KMP workflows.

## Required repo secrets (please add)

`GRADLE_CACHE_URL`, `GRADLE_CACHE_USERNAME` (`meshtastic`), `GRADLE_CACHE_PASSWORD`. Absent them, the remote cache disables itself (local + Konan cache still work) — CI never breaks.

## Notes

`actionlint` clean on all three workflows. Only touches the KMP packaging/CI — no `.proto` or generated-code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
