### PR TITLE
feat: add RAK WisMesh Pocket / Repeater Mini / Pod hardware models

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -949,6 +949,26 @@ enum HardwareModel {
   HELTEC_RCC6 = 143;
 
   /*
+   * RAKwireless WisMesh Pocket V3
+   */
+  WISMESH_POCKET = 144;
+
+  /*
+   * RAKwireless WisMesh Repeater Mini V2
+   */
+  WISMESH_REPEATER_MINI = 145;
+
+  /*
+   * RAKwireless WisMesh Repeater Mini V2 HP
+   */
+  WISMESH_REPEATER_MINI_HP = 146;
+
+  /*
+   * RAKwireless WisMesh Pod
+   */
+  WISMESH_POD = 147;
+
+  /*
    * ------------------------------------------------------------------------------------------------------------------------------------------
    * Reserved ID For developing private Ports. These will show up in live traffic sparsely, so we can use a high number. Keep it within 8 bits.
    * ------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do?

Adds official `HardwareModel` enum values for RAKwireless WisMesh product variants that already have firmware envs merged (or in flight), so devices can report distinct models for App OTA matching, NodeInfo, and Web Flasher metadata — instead of inheriting parent models (`RAK4631` / `RAK3401` / `WISMESH_TAG`).

> Related firmware envs: `rak_wismesh_pocket`, `rak_wismesh_repeater_mini`, `rak_wismesh_repeater_mini_hp`, `rak_wismesh_pod`

## New HardwareModel values

| ID | Enum | Product |
|----|------|---------|
| 144 | `WISMESH_POCKET` | RAK WisMesh Pocket V3 |
| 145 | `WISMESH_REPEATER_MINI` | RAK WisMesh Repeater Mini V2 |
| 146 | `WISMESH_REPEATER_MINI_HP` | RAK WisMesh Repeater Mini V2 HP |
| 147 | `WISMESH_POD` | RAK WisMesh Pod |

## Why now

- **Pocket** diverges from generic `RAK4631` (e.g. GPS `PIN_GPS_EN` / power behavior); sharing parent `hw_model` risks wrong App OTA target and incorrect GPS EN special-casing.
- **Repeater Mini / HP / Pod** currently run on parent models; dedicated IDs give correct product identity before a public release ships.
- RAK is a Meshtastic partner; requesting official model numbers prior to release.

## Follow-up (firmware, separate PR)

After this merges and firmware protobufs sync:
- Map `HW_VENDOR` in `src/platform/nrf52/architecture.h` (before parent `RAK4630` / `WISMESH_TAG` branches)
- Set `custom_meshtastic_hw_model` / `custom_meshtastic_hw_model_slug` on each env

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying four RAKwireless WisMesh device models:
    * WisMesh Pocket
    * WisMesh Repeater Mini
    * WisMesh Repeater Mini HP
    * WisMesh Pod

<!-- end of auto-generated comment: release notes by coderabbit.ai -->