### PR TITLE
add preamble_length to settings list

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1256,6 +1256,11 @@ message Config {
      * Don't use radiolib to initialize the radio, instead listen for a serialHal connection
      */
     bool serial_hal_only = 107;
+
+    /*
+     * The length of the preamble in symbols
+     */
+    uint32 preamble_length = 108;
   }
 
   message BluetoothConfig {


### PR DESCRIPTION
Adding preamble_length in Lora config list, to get ability change this parameter.

For what?

To controlling external Power Amplifier, specially  for old half_duplex PA with RF relays
<img width="2560" height="798" alt="96d31e8a-8b38-4b5d-98a6-96665dc08aa7" src="https://github.com/user-attachments/assets/fe0499e9-8a34-4993-a9db-d1ae84aad978" />
<img width="2560" height="798" alt="15e82cfd-92b0-4773-80f3-1a5e70676ba1" src="https://github.com/user-attachments/assets/10c11021-89f1-4a68-91ab-df77f0a41647" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable LoRa preamble length setting.
  * Included documentation for the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->