### PR TITLE
feat: distinguish PKI decrypt failures

### DIFF
--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1167,6 +1167,13 @@ message Routing {
      * This is different from PKI_UNKNOWN_PUBKEY which indicates a failure upon receiving a packet
      */
     PKI_SEND_FAIL_PUBLIC_KEY = 39;
+
+    /*
+     * PKI packet could not be decrypted, even though the sender's public key is in NodeDB.
+     * Typically happens after the sender rotated keys; may also happen due to RF corruption or
+     * builds without PKI support (MESHTASTIC_EXCLUDE_PKI).
+     */
+    PKI_DECRYPT_FAILED = 40;
   }
 
   oneof variant {


### PR DESCRIPTION
Adds the existing proposed `PKI_DECRYPT_FAILED` routing error on top of the current protobuf schema.

This lets firmware distinguish an addressed PKI message that cannot authenticate with a stored sender key from an unknown-sender key-exchange request or an ordinary channel failure.

Validated by regenerating the firmware bindings and running the native packet-signing suite against the dependent firmware change.