### PR TITLE
feat: add remote telemetry request policies

### DIFF
--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1294,6 +1294,21 @@ message Config {
 
   message SecurityConfig {
     /*
+     * Controls which remote nodes may request LocalStats.
+     */
+    enum LocalStatsRequestPolicy {
+      /*
+       * Accept LocalStats requests using normal shared-channel encryption.
+       */
+      LOCAL_STATS_REQUEST_POLICY_CHANNEL = 0;
+
+      /*
+       * Accept remote LocalStats requests only when PKI-authenticated by an authorized admin key.
+       */
+      LOCAL_STATS_REQUEST_POLICY_ADMIN_PKI = 1;
+    }
+
+    /*
      * Controls how the device authenticates remotely received mesh packets.
      */
     enum PacketSignaturePolicy {
@@ -1359,6 +1374,11 @@ message Config {
      * Determines the packet signature policy applied to remotely received mesh packets.
      */
     PacketSignaturePolicy packet_signature_policy = 9;
+
+    /*
+     * Determines which remote nodes may request LocalStats. Directly connected clients remain trusted.
+     */
+    LocalStatsRequestPolicy local_stats_request_policy = 10;
   }
 
   /*

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -1309,6 +1309,21 @@ message Config {
     }
 
     /*
+     * Controls which remote nodes may request DeviceMetrics when device telemetry broadcasting is disabled.
+     */
+    enum DeviceTelemetryRequestPolicy {
+      /*
+       * Accept DeviceMetrics requests using normal shared-channel encryption.
+       */
+      DEVICE_TELEMETRY_REQUEST_POLICY_CHANNEL = 0;
+
+      /*
+       * Accept remote DeviceMetrics requests only when PKI-authenticated by an authorized admin key.
+       */
+      DEVICE_TELEMETRY_REQUEST_POLICY_ADMIN_PKI = 1;
+    }
+
+    /*
      * Controls how the device authenticates remotely received mesh packets.
      */
     enum PacketSignaturePolicy {
@@ -1379,6 +1394,12 @@ message Config {
      * Determines which remote nodes may request LocalStats. Directly connected clients remain trusted.
      */
     LocalStatsRequestPolicy local_stats_request_policy = 10;
+
+    /*
+     * Determines which remote nodes may request DeviceMetrics while device telemetry broadcasting is disabled.
+     * This setting is ignored while device telemetry broadcasting is enabled. Directly connected clients remain trusted.
+     */
+    DeviceTelemetryRequestPolicy device_telemetry_request_policy = 11;
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -679,7 +679,6 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
-
   }
 
   /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -679,6 +679,7 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
+
   }
 
   /*


### PR DESCRIPTION
# What does this PR do?

Adds two device-owned `SecurityConfig` request policies for detailed radio telemetry:

- `local_stats_request_policy` controls detailed LocalStats.
- `device_telemetry_request_policy` controls requested DeviceMetrics only while `TelemetryConfig.device_telemetry_enabled` is false. It is ignored while DeviceMetrics broadcasting is enabled.

Each policy is an enum with a compatible default, `CHANNEL`, and an opt-in `ADMIN_PKI` mode. `CHANNEL` keeps normal shared-channel encryption. `ADMIN_PKI` allows firmware to require a PKI-authenticated request from a configured remote-admin key. Direct attached-client requests remain trusted.

This does **not** add NodeInfo/capability broadcasting or publish remote-admin membership. Remote clients choose the transport only at a user-initiated request; firmware returns the existing correlated `NOT_AUTHORIZED` routing NAK when that method or identity is rejected.

> [Related firmware issue](https://github.com/meshtastic/firmware/issues/11247)

## Validation

- `buf format --diff --exit-code`
- `buf lint`
- `buf breaking --against https://github.com/meshtastic/protobufs.git#format=git,commit=bfd718fa1dcb019ed11b7b7185f37318abebdafc`
- `buf generate`; verified TypeScript emits both policy enums and fields. Generated TypeScript is intentionally ignored and regenerated by the publish workflow.

## Checklist before merging

- [x] All top level messages commented
- [x] All enum members have unique descriptions
- [x] Hardware model policy is not applicable (no hardware changes)