### PR TITLE
Rssi explicit presence

### DIFF
--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -11,6 +11,9 @@
 *NodeInfoLite.channel int_size:8
 *NodeInfoLite.hops_away int_size:8
 *NodeInfoLite.next_hop int_size:8
+# Real range is roughly -164..+98 (SX127x low-band offset .. positive-RSSI edge case, see
+# phantom-zero-hop-direct-nodes bug notes) - int8 can't hold it, int16 comfortably can.
+*NodeInfoLite.rssi int_size:16
 
 # Flattened user fields. long_name was 40 on UserLite; trimmed to 25 here so the
 # slim header gives back ~15 B/node of RAM. Names that exceeded 24 chars on the

--- a/meshtastic/deviceonly.options
+++ b/meshtastic/deviceonly.options
@@ -11,9 +11,6 @@
 *NodeInfoLite.channel int_size:8
 *NodeInfoLite.hops_away int_size:8
 *NodeInfoLite.next_hop int_size:8
-# Real range is roughly -164..+98 (SX127x low-band offset .. positive-RSSI edge case, see
-# phantom-zero-hop-direct-nodes bug notes) - int8 can't hold it, int16 comfortably can.
-*NodeInfoLite.rssi int_size:16
 
 # Flattened user fields. long_name was 40 on UserLite; trimmed to 25 here so the
 # slim header gives back ~15 B/node of RAM. Names that exceeded 24 chars on the

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -194,14 +194,6 @@ message NodeInfoLite {
    * "never measured".
    */
   sint32 snr_q4 = 19;
-
-  /*
-   * Last received RSSI (dBm) for this node, restored into replayed packets so history sent to
-   * the phone after a reconnect isn't misrepresented as a live zero-signal reception. A stored
-   * 0 does not by itself mean "unknown" - RSSI can legitimately read 0 dBm or, on some radios,
-   * positive. See NODEINFO_BITFIELD_HAS_RSSI in src/mesh/NodeDB.h for the presence bit.
-   */
-  sint32 rssi = 20;
 }
 
 /*

--- a/meshtastic/deviceonly.proto
+++ b/meshtastic/deviceonly.proto
@@ -187,10 +187,21 @@ message NodeInfoLite {
 
   /*
    * Q4-encoded SNR: dB × 4, sint32 zigzag. Matches RouteDiscovery convention.
-   * Encode: snr_q4 = (int32_t)(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
+   * Encode: snr_q4 = (int32_t)lroundf(snr * 4.0f). Decode: snr = snr_q4 / 4.0f.
    * float snr is always zeroed on disk; this field carries all persisted SNR.
+   * A stored 0 does not by itself mean "unknown" here - see NODEINFO_BITFIELD_HAS_SNR in
+   * src/mesh/NodeDB.h for the presence bit that disambiguates a genuine 0 dB reading from
+   * "never measured".
    */
   sint32 snr_q4 = 19;
+
+  /*
+   * Last received RSSI (dBm) for this node, restored into replayed packets so history sent to
+   * the phone after a reconnect isn't misrepresented as a live zero-signal reception. A stored
+   * 0 does not by itself mean "unknown" - RSSI can legitimately read 0 dBm or, on some radios,
+   * positive. See NODEINFO_BITFIELD_HAS_RSSI in src/mesh/NodeDB.h for the presence bit.
+   */
+  sint32 rssi = 20;
 }
 
 /*

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1848,8 +1848,13 @@ message MeshPacket {
 
   /*
    * rssi of received packet. Only sent to phone for dispay purposes.
+   * Explicit presence: rssi 0 is a legitimate reading on some radios (SX126x can report exactly
+   * 0 dBm; SX127x's formula can even go positive), so implicit-presence proto3 made an unset
+   * value indistinguishable from a measured one. has_rx_rssi disambiguates; a replayed packet
+   * built from history the device never restored an RSSI for should leave this field absent
+   * rather than emitting 0.
    */
-  int32 rx_rssi = 12;
+  optional int32 rx_rssi = 12;
 
   /*
    * Describe if this message is delayed

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -1849,10 +1849,8 @@ message MeshPacket {
   /*
    * rssi of received packet. Only sent to phone for dispay purposes.
    * Explicit presence: rssi 0 is a legitimate reading on some radios (SX126x can report exactly
-   * 0 dBm; SX127x's formula can even go positive), so implicit-presence proto3 made an unset
-   * value indistinguishable from a measured one. has_rx_rssi disambiguates; a replayed packet
-   * built from history the device never restored an RSSI for should leave this field absent
-   * rather than emitting 0.
+   * 0 dBm; SX127x's formula can even go positive). has_rx_rssi disambiguates; a replayed packet
+   * built from history should leave this field absent rather than emitting 0.
    */
   optional int32 rx_rssi = 12;
 
@@ -1869,6 +1867,10 @@ message MeshPacket {
   /*
    * Hop limit with which the original packet started. Sent via LoRa using three bits in the unencrypted header.
    * When receiving a packet, the difference between hop_start and hop_limit gives how many hops it traveled.
+   * hop_start == 0 does not necessarily mean a direct (0-hop) neighbor: firmware prior to 2.3.0
+   * never populated this field, so a receiver can only trust hop_start == 0 as genuine once it has
+   * decoded the packet and confirmed the sender's bitfield is present (added in 2.5.0). Until then,
+   * or for a sender that never sets that bitfield, treat hop_start == 0 as unknown, not direct.
    */
   uint32 hop_start = 15;
 


### PR DESCRIPTION
make rx_rssi optional

needed for https://github.com/meshtastic/firmware/pull/11271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of signal-strength readings so valid 0 dB values are distinguished from unavailable measurements.
  * Clarified how unknown signal and hop information is represented, including for replayed or historical packets.
  * Improved accuracy of quarter-decibel SNR values through rounded encoding.

* **Documentation**
  * Updated protocol guidance to clarify when signal and hop values should be considered unknown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->