### PR TITLE
feat: add DeviceUIConfig.screen_rotation

### DIFF
--- a/meshtastic/device_ui.proto
+++ b/meshtastic/device_ui.proto
@@ -95,6 +95,12 @@ message DeviceUIConfig {
   GpsCoordinateFormat gps_format = 19;
 
   /*
+   * Screen rotation of the color UI (MUI), relative to the device's built-in
+   * display orientation. Applied at boot; changing it requires a restart.
+   */
+  ScreenRotation screen_rotation = 20;
+
+  /*
    * How the GPS coordinates are displayed on the OLED screen.
    */
   enum GpsCoordinateFormat {
@@ -140,6 +146,33 @@ message DeviceUIConfig {
      * Described here: https://en.wikipedia.org/wiki/Maidenhead_Locator_System
      */
     MLS = 6;
+  }
+
+  /*
+   * Quarter-turn rotation of the color UI relative to the device's built-in
+   * display orientation.
+   */
+  enum ScreenRotation {
+    /*
+     * The device's built-in display orientation, unrotated.
+     */
+    ROTATION_0 = 0;
+
+    /*
+     * A quarter turn from the built-in orientation, swapping width and height.
+     */
+    ROTATION_90 = 1;
+
+    /*
+     * Upside down relative to the built-in orientation.
+     */
+    ROTATION_180 = 2;
+
+    /*
+     * Three quarter turns from the built-in orientation, swapping width and
+     * height.
+     */
+    ROTATION_270 = 3;
   }
 }
 


### PR DESCRIPTION
# What does this PR do?

Adds a persisted screen rotation to `DeviceUIConfig` so the color UI can offer
orientation as a runtime setting instead of a build-time choice.

Today a device that can render both the 320x240 and the 240x320 layout has to
pick one at compile time via `VIEW_320x240` / `VIEW_240x320`. There is nowhere
to store a user's choice, so the only way to change orientation is to reflash.

The device-ui side that consumes this field is implemented and hardware-tested;
see the companion PR linked below.

## The field

```proto
ScreenRotation screen_rotation = 20;

enum ScreenRotation {
  ROTATION_0   = 0;
  ROTATION_90  = 1;
  ROTATION_180 = 2;
  ROTATION_270 = 3;
}
```

Quarter turns **relative to the device's built-in display orientation**, not
absolute panel rotations.

- **`ROTATION_0` is the existing behaviour.** Every device that never sets this
  field keeps rendering exactly as it does today, and the default value of an
  unset proto3 enum is 0, so no migration is involved.
- The 0..3 quarter-turn numbering matches LVGL's `LV_DISPLAY_ROTATION_*` and the
  masking already used for `MESHTASTIC_FB_ROTATION` in device-ui #355 — same
  concept, same numbering, different transport.
- It is read at boot. Changing it needs a restart, because an LVGL layout tree
  cannot be rebuilt in place once the view has cached its object pointers. The
  comment says so.

## Why in the proto rather than firmware-side

Open question for you, and I'm happy either way:

`DeviceUIConfig` is where every other persisted MUI setting already lives
(brightness, theme, language, touch calibration), and it reaches the firmware
through the existing `storeUIConfig` path, so device-ui needs no new plumbing
and the phone app could surface it later.

The alternative is a firmware-owned byte with device-ui exposing a small
load/store hook. That avoids touching the wire format entirely, at the cost of a
private file, no app visibility, and a `GIT_TAG`/submodule bump chain to get the
generated bindings anywhere.

If you'd rather not spend a field number on this, say so and I'll redo it the
firmware-owned way — the device-ui implementation is unaffected apart from where
it reads and writes the value.

## Checklist

- [x] All top level messages commented (no new messages)
- [x] All enum members have unique descriptions
- [x] `buf format` clean

## Companion PR

device-ui implementation: https://github.com/meshtastic/device-ui/pull/359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting color UI screen rotation: 0°, 90°, 180°, or 270°.
  * Device display orientation can now be configured through device settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->