### PR TITLE
Add cellular (Air780E/EC618) modem config and telemetry fields

### DIFF
--- a/meshtastic/config.options
+++ b/meshtastic/config.options
@@ -8,6 +8,11 @@
 *NetworkConfig.ntp_server max_size:33
 *NetworkConfig.rsyslog_server max_size:33
 
+# APN is up to 100 octets per 3GPP TS 23.003
+*NetworkConfig.cell_apn max_size:101
+*NetworkConfig.cell_apn_user max_size:65
+*NetworkConfig.cell_apn_pass max_size:65
+
 # Max of three ignored nodes for our testing
 *LoRaConfig.ignore_incoming max_count:3
 

--- a/meshtastic/config.proto
+++ b/meshtastic/config.proto
@@ -579,6 +579,33 @@ message Config {
     bool ipv6_enabled = 11;
 
     /*
+     * Enable Cellular (modem) networking
+     */
+    bool cell_enabled = 12;
+
+    /*
+     * APN to use when bringing up the cellular PDP context. Empty string asks for the
+     * subscription default.
+     */
+    string cell_apn = 13;
+
+    /*
+     * Username for the cellular APN, if required
+     */
+    string cell_apn_user = 14;
+
+    /*
+     * Password for the cellular APN, if required
+     */
+    string cell_apn_pass = 15;
+
+    /*
+     * Allow the cellular modem to register on a roaming network. Disabled restricts
+     * registration to the home network only.
+     */
+    bool cell_roaming_enabled = 16;
+
+    /*
      * Available flags auxiliary network protocols
      */
     enum ProtocolFlags {

--- a/meshtastic/mesh.proto
+++ b/meshtastic/mesh.proto
@@ -2786,6 +2786,11 @@ message DeviceMetadata {
    * This is a read-only capability and must be false when XEdDSA is not compiled in.
    */
   bool has_xeddsa = 14;
+
+  /*
+   * Indicates that the device has a cellular (modem) peripheral
+   */
+  bool hasCellular = 15;
 }
 
 /*

--- a/meshtastic/module_config.proto
+++ b/meshtastic/module_config.proto
@@ -679,6 +679,17 @@ message ModuleConfig {
      * Enable/Disable the air quality telemetry measurement module on-device display
      */
     bool air_quality_screen_enabled = 15;
+
+    /*
+     * Enable/disable Cellular (modem) diagnostic metrics
+     */
+    bool cellular_measurement_enabled = 16;
+
+    /*
+     * Interval in seconds of how often we should try to send our
+     * cellular diagnostic metrics to the mesh
+     */
+    uint32 cellular_update_interval = 17;
   }
 
   /*

--- a/meshtastic/telemetry.options
+++ b/meshtastic/telemetry.options
@@ -17,3 +17,5 @@
 *HostMetrics.load5 int_size:16
 *HostMetrics.load15 int_size:16
 *HostMetrics.user_string max_size:200
+
+*CellularMetrics.operator_name max_size:24

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -567,6 +567,41 @@ message HostMetrics {
 }
 
 /*
+ * Cellular (modem) diagnostic metrics
+ */
+message CellularMetrics {
+  /*
+   * Reference Signal Received Power, in dBm
+   */
+  optional int32 rsrp = 1;
+
+  /*
+   * Reference Signal Received Quality, in dB
+   */
+  optional float rsrq = 2;
+
+  /*
+   * E-UTRA band number
+   */
+  optional uint32 band = 3;
+
+  /*
+   * Access technology, 7 = E-UTRAN
+   */
+  optional uint32 access_tech = 4;
+
+  /*
+   * Modem supply voltage, in millivolts
+   */
+  optional uint32 modem_voltage_mv = 5;
+
+  /*
+   * PLMN operator name, or the numeric MCC/MNC when unresolved
+   */
+  optional string operator_name = 6;
+}
+
+/*
  * Types of Measurements the telemetry module is equipped to handle
  */
 message Telemetry {
@@ -615,6 +650,11 @@ message Telemetry {
      * Traffic management statistics
      */
     TrafficManagementStats traffic_management_stats = 9;
+
+    /*
+     * Cellular (modem) diagnostic metrics
+     */
+    CellularMetrics cellular_metrics = 10;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds protobuf fields for the cellular (Air780E/EC618) modem support landing in meshtastic/firmware, replacing build-time defines with configurable fields following the existing WiFi/Ethernet pattern.

- `Config.NetworkConfig` gains `cell_enabled`, `cell_apn`, `cell_apn_user`, `cell_apn_pass`, `cell_roaming_enabled` (fields 12-16), mirroring `wifi_enabled`/`wifi_ssid`/`wifi_psk`, with nanopb `.options` sizing matching the wifi string fields.
- `DeviceMetadata` gains `hasCellular` (field 15), alongside `hasWifi`/`hasEthernet`/`hasBluetooth`.
- `Telemetry` gains a `CellularMetrics` variant (field 10) carrying RSRP, RSRQ, band, access technology, modem supply voltage, and operator name, matching the firmware's existing `CellDiag` diagnostics struct.
- `ModuleConfig.TelemetryConfig` gains `cellular_measurement_enabled`/`cellular_update_interval` (fields 16-17), mirroring the power/health/air-quality telemetry toggles.

Firmware consumer: meshtastic/firmware#11375 (draft, blocked on this PR merging).

## Test plan

- [ ] `buf lint`/`buf format` clean (repo CI)
- [ ] Regenerated nanopb output compiles in meshtastic/firmware against these fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cellular modem networking configuration, including enablement, roaming control, APN, credentials, and validation limits.
  * Devices can now report cellular modem capability.
  * Added cellular diagnostic telemetry for signal strength, network technology, frequency band, modem voltage, and operator details.
  * Added controls for enabling cellular measurements and setting their reporting interval.
  * Cellular diagnostics support monitoring modem connectivity and network conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
