### PR TITLE
Add SEN6X fields

### DIFF
--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -809,7 +809,7 @@ message SensorConfig {
    * DS248X-800 temperature sensor configuration
    */
   DS248X_config ds248x_config = 5;
-   
+
   /*
    * SEN6X PM/RHT/VOC/NOx/CO2/HCHO Sensor configuration
    */

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -887,7 +887,7 @@ message SEN6X_config {
   optional bool set_asc = 4;
 
   /*
-   * Recalibration target CO2 concentration in ppm (FRC or ASC), CO2-capable variants only
+   * Recalibration target CO2 concentration in ppm (FRC only), CO2-capable variants only
    */
   optional uint32 set_target_co2_conc = 5;
 
@@ -902,7 +902,7 @@ message SEN6X_config {
   optional uint32 set_ambient_pressure = 7;
 
   /*
-   * Perform a factory reset of the CO2 sensor's calibration history, CO2-capable variants only
+   * Perform a factory reset of the CO2 sensor's calibration, CO2-capable variants only
    */
   optional bool factory_reset = 8;
 }

--- a/meshtastic/admin.proto
+++ b/meshtastic/admin.proto
@@ -804,6 +804,11 @@ message SensorConfig {
    * SHTXX temperature and relative humidity sensor configuration
    */
   SHTXX_config shtxx_config = 4;
+
+  /*
+   * SEN6X PM/RHT/VOC/NOx/CO2/HCHO Sensor configuration
+   */
+  SEN6X_config sen6x_config = 5;
 }
 
 message SCD4X_config {
@@ -853,6 +858,53 @@ message SEN5X_config {
    * One-shot mode (true for low power - one-shot mode, false for normal - continuous mode)
    */
   optional bool set_one_shot_mode = 2;
+
+  /*
+   * Trigger a fan cleaning cycle
+   */
+  optional bool start_fan_cleaning = 3;
+}
+
+message SEN6X_config {
+  /*
+   * Reference temperature in degC
+   */
+  optional float set_temperature = 1;
+
+  /*
+   * One-shot mode (true for low power - one-shot mode, false for normal - continuous mode)
+   */
+  optional bool set_one_shot_mode = 2;
+
+  /*
+   * Trigger a fan cleaning cycle
+   */
+  optional bool start_fan_cleaning = 3;
+
+  /*
+   * Set Automatic self-calibration enabled (CO2-capable variants only: SEN63C, SEN66, SEN69C)
+   */
+  optional bool set_asc = 4;
+
+  /*
+   * Recalibration target CO2 concentration in ppm (FRC or ASC), CO2-capable variants only
+   */
+  optional uint32 set_target_co2_conc = 5;
+
+  /*
+   * Altitude of sensor in meters above sea level. 0 - 3000m (overrides ambient pressure), CO2-capable variants only
+   */
+  optional uint32 set_altitude = 6;
+
+  /*
+   * Sensor ambient pressure in Pa. 70000 - 120000 Pa (overrides altitude), CO2-capable variants only
+   */
+  optional uint32 set_ambient_pressure = 7;
+
+  /*
+   * Perform a factory reset of the CO2 sensor's calibration history, CO2-capable variants only
+   */
+  optional bool factory_reset = 8;
 }
 
 message SCD30_config {

--- a/meshtastic/telemetry.proto
+++ b/meshtastic/telemetry.proto
@@ -373,6 +373,14 @@ message AirQualityMetrics {
    * Typical Particle Size in um
    */
   optional float particles_tps = 25;
+
+  /*
+   * Raw PM sensor device status/error register bitmask, as defined by the sensor's own datasheet
+   * (currently populated by the SEN6X family: bit 4 fan error, bit 6 RH&T error, bit 7 gas/VOC-NOx
+   * error, bit 9 CO2 error (SEN66), bit 10 HCHO error, bit 11 PM error, bit 12 CO2 error (SEN63C/SEN69C),
+   * bit 21 fan speed warning)
+   */
+  optional uint32 pm_status_flags = 26;
 }
 
 /*
@@ -901,6 +909,11 @@ enum TelemetrySensorType {
    * HM330X PM SENSOR
    */
   HM330X = 55;
+
+  /*
+   * Sensirion SEN6X PM/RHT/VOC/NOx/CO2/HCHO sensor family (SEN62, SEN63C, SEN65, SEN66, SEN68, SEN69C)
+   */
+  SEN6X = 56;
 }
 
 /*
@@ -919,7 +932,7 @@ message Nau7802Config {
 }
 
 /*
- * SEN5X State, for saving to flash
+ * SEN5X State, for saving to flash (to be merged with SEN6XState)
  */
 message SEN5XState {
   /*
@@ -949,6 +962,41 @@ message SEN5XState {
 
   /*
    * VOC state array (8x uint8t) for SEN55
+   */
+  optional fixed64 voc_state_array = 6;
+}
+
+/*
+ * SEN6X State, for saving to flash
+ */
+message SEN6XState {
+  /*
+   * Last cleaning time for SEN6X
+   */
+  uint32 last_cleaning_time = 1;
+
+  /*
+   * Last cleaning time for SEN6X - valid flag
+   */
+  bool last_cleaning_valid = 2;
+
+  /*
+   * Config flag for one-shot mode (see admin.proto)
+   */
+  bool one_shot_mode = 3;
+
+  /*
+   * Last VOC state time, for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
+   */
+  optional uint32 voc_state_time = 4;
+
+  /*
+   * Last VOC state validity flag, for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
+   */
+  optional bool voc_state_valid = 5;
+
+  /*
+   * VOC state array (8x uint8t), for models with a VOC sensor (SEN65, SEN66, SEN68, SEN69C)
    */
   optional fixed64 voc_state_array = 6;
 }


### PR DESCRIPTION
This PR adds support for the new versions of the Sensirion PM sensors (SEN6X series) integrating CO2, HCHO, PM, T/H and all sort of other things. The firmware PR will also merge classes with SEN5X as they share most commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SEN6X air-quality sensors.
  * Added configuration options for temperature, one-shot measurements, fan cleaning, CO₂ calibration, altitude, pressure, and factory reset.
  * Added SEN6X cleaning, measurement, and VOC calibration status reporting.
  * Added particulate-matter sensor status and error indicators.
  * Added fan-cleaning control for SEN5X sensors.
  * Added support for monitoring sensor health and operational state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->