### PR TITLE
Trim unused DrawnShape.vertices

### DIFF
--- a/meshtastic/atak.options
+++ b/meshtastic/atak.options
@@ -44,7 +44,6 @@
 # / fill_argb are fixed32 (always 4 bytes on the wire). Vertex pool is 32
 # entries x ~12B each ~= 384B worst case. Telestrations beyond 32 vertices
 # MUST be pre-truncated by the sender with `truncated = true`.
-*DrawnShape.vertices max_count:32
 *DrawnShape.major_cm int_size:32
 *DrawnShape.minor_cm int_size:32
 *DrawnShape.angle_deg int_size:16


### PR DESCRIPTION
This emits a warning if not removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the maximum vertex limit for drawn shapes, allowing more complex shapes to be created.
  * Retained the existing 48-character limit for task request notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->